### PR TITLE
Persist 'Controllers Allowed' setting

### DIFF
--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2549,7 +2549,7 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
         ImGui::Checkbox("Disable VR Entirely", &m_disable_vr);
         ImGui::Checkbox("Stereo Emulation Mode", &m_stereo_emulation_mode);
         ImGui::Checkbox("Wait for Present", &m_wait_for_present);
-        ImGui::Checkbox("Controllers allowed", &m_controllers_allowed);
+        m_controllers_allowed->draw("Controllers allowed");
         ImGui::Checkbox("Controller test mode", &m_controller_test_mode);
 
         const double min_ = 0.0;

--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -280,12 +280,12 @@ public:
     }
 
     bool is_using_controllers() const {
-        return m_controller_test_mode || (m_controllers_allowed &&
+        return m_controller_test_mode || (m_controllers_allowed->value() &&
         is_hmd_active() && !m_controllers.empty() && (std::chrono::steady_clock::now() - m_last_controller_update) <= std::chrono::seconds((int32_t)m_motion_controls_inactivity_timer->value()));
     }
 
     bool is_using_controllers_within(std::chrono::seconds seconds) const {
-        return is_hmd_active() && !m_controllers.empty() && (std::chrono::steady_clock::now() - m_last_controller_update) <= seconds;
+        return m_controllers_allowed->value() && is_hmd_active() && !m_controllers.empty() && (std::chrono::steady_clock::now() - m_last_controller_update) <= seconds;
     }
 
     int get_hmd_index() const {
@@ -892,7 +892,7 @@ private:
 
     bool m_stereo_emulation_mode{false}; // not a good config option, just for debugging
     bool m_wait_for_present{true};
-    bool m_controllers_allowed{true};
+    const ModToggle::Ptr m_controllers_allowed{ ModToggle::create(generate_name("ControllersAllowed"), true) };
     bool m_controller_test_mode{false};
 
     ValueList m_options{
@@ -949,6 +949,7 @@ private:
         *m_keybind_disable_vr,
         *m_keybind_toggle_gui,
         *m_requested_runtime_name,
+        *m_controllers_allowed,
     };
     
 


### PR DESCRIPTION
When using Virtual Desktop toggling performance overlay (both thumbsticks down on VR controllers) disconnects gamepad in some games.

This patch allows to write state of 'Debug->Controllers Allowed' setting to config.txt making a workaround in game profile possible.

VR.is_using_controllers_within() was not respecting the setting making gamepad disconnect on game exit. This is also fixed.