### PR TITLE
Added option to set log level to UI 'debug' tab

### DIFF
--- a/src/Framework.cpp
+++ b/src/Framework.cpp
@@ -1379,7 +1379,7 @@ void Framework::draw_ui() {
             set_mouse_to_center();
             patch_set_cursor_pos();
         }
-
+        spdlog::set_level(static_cast<spdlog::level::level_enum>(VR::get()->get_log_level()));
         m_draw_ui = m_last_draw_ui;
         set_draw_ui(!m_draw_ui, true);
     }

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2531,7 +2531,7 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
         if (m_fake_stereo_hook != nullptr) {
             m_fake_stereo_hook->on_draw_ui();
         }
-
+        m_log_level->draw("Log Level");
         ImGui::Combo("Sync Mode", (int*)&get_runtime()->custom_stage, "Early\0Late\0Very Late\0");
         ImGui::DragFloat4("Right Bounds", (float*)&m_right_bounds, 0.005f, -2.0f, 2.0f);
         ImGui::DragFloat4("Left Bounds", (float*)&m_left_bounds, 0.005f, -2.0f, 2.0f);

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -1713,6 +1713,9 @@ void VR::on_config_load(const utility::Config& cfg, bool set_defaults) {
 
     // Load camera offsets
     load_cameras();
+
+    // update the logging level
+    spdlog::set_level(static_cast<spdlog::level::level_enum>(this->get_log_level()));
 }
 
 void VR::on_config_save(utility::Config& cfg) {

--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -82,6 +82,8 @@ public:
 public:
     static std::shared_ptr<VR>& get();
 
+    int get_log_level() { return m_log_level->value(); }
+
     std::string_view get_name() const override { return "VR"; }
 
     std::optional<std::string> clean_initialize();
@@ -741,6 +743,15 @@ private:
         "Alternating/AFR",
     };
 
+    static const inline std::vector<std::string> s_log_level_names {
+        "Trace",
+        "Debug",
+        "Info",
+        "Warn",
+        "Error",
+        "Critical"
+    };
+
     static const inline std::vector<std::string> s_synced_afr_method_names {
         "Skip Tick",
         "Skip Draw",
@@ -764,6 +775,7 @@ private:
         "Gesture (Head) + Right Joystick",
     };
 
+    const ModCombo::Ptr m_log_level{ ModCombo::create(generate_name("LogLevel"), s_log_level_names, SPDLOG_LEVEL_INFO) };
     const ModCombo::Ptr m_rendering_method{ ModCombo::create(generate_name("RenderingMethod"), s_rendering_method_names) };
     const ModCombo::Ptr m_synced_afr_method{ ModCombo::create(generate_name("SyncedSequentialMethod"), s_synced_afr_method_names, 1) };
     const ModToggle::Ptr m_extreme_compat_mode{ ModToggle::create(generate_name("ExtremeCompatibilityMode"), false, true) };
@@ -889,6 +901,7 @@ private:
     bool m_controller_test_mode{false};
 
     ValueList m_options{
+        *m_log_level,
         *m_rendering_method,
         *m_synced_afr_method,
         *m_extreme_compat_mode,


### PR DESCRIPTION
add a Log Level element to the Debug page. Defaults to INFO, calls spdlog::set_level with the value (cast from into to the level enum) when the UI is closed