### PR TITLE
Add two DPAD shifting methods

### DIFF
--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -52,6 +52,8 @@ public:
         RIGHT_JOYSTICK,
         GESTURE_HEAD,
         GESTURE_HEAD_RIGHT,
+        RIGHT_JOYSTICK_CLICK,
+        LEFT_JOYSTICK_CLICK
     };
 
     static const inline std::string s_action_pose = "/actions/default/in/Pose";
@@ -762,6 +764,8 @@ private:
         "Right Joystick (Disables Standard Joystick Input)",
         "Gesture (Head) + Left Joystick",
         "Gesture (Head) + Right Joystick",
+        "Right Joystick Press + Left Joystick (Disables R3)",
+        "Left Joystick Press + Right Joystick (Disables L3)"
     };
 
     const ModCombo::Ptr m_rendering_method{ ModCombo::create(generate_name("RenderingMethod"), s_rendering_method_names) };


### PR DESCRIPTION
Two DPAD shifting methods, "Right Joystick Press + Left Joystick" and "Left Joystick Press + Right Joystick", are added.
Non-Oculus users can benefit from these methods in case they are unwilling or unable to use the gesture-based methods, e.g., when they are lying in bed.

The new methods will disable the R3 and L3 mapping respectively, except one can press L3 + R3 to toggle the UEVR menu.
When "Left Joystick Press + Right Joystick" is used, snapturn is temporarily disabled when the left joystick is pressed.
Tested with a few games. 
test device: Pico 4 + VD openXR 