### PR TITLE
Add controller rotation / position offsets

### DIFF
--- a/src/mods/UObjectHook.cpp
+++ b/src/mods/UObjectHook.cpp
@@ -430,8 +430,8 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
         return;
     }
 
-    glm::vec3 right_hand_position = vr->get_grip_position(vr->get_right_controller_index());
-    glm::quat right_hand_rotation = vr->get_right_controller_aim_rotation_with_offset();//  vr->get_aim_rotation(vr->get_right_controller_index());
+    glm::vec3 right_hand_position = vr->get_controller_position_with_offset(VR::Side::RIGHT);
+    glm::quat right_hand_rotation = vr->get_controller_rotation_with_offset(VR::Side::RIGHT);//  vr->get_aim_rotation(vr->get_right_controller_index());
 
     const float lerp_speed = m_attach_lerp_speed->value() * m_last_delta_time;
 
@@ -452,8 +452,8 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
     const auto original_right_hand_rotation = right_hand_rotation;
     const auto original_right_hand_position = right_hand_position - hmd_origin;
 
-    glm::vec3 left_hand_position = vr->get_grip_position(vr->get_left_controller_index());
-    glm::quat left_hand_rotation = vr->get_left_controller_aim_rotation_with_offset(); // vr->get_aim_rotation(vr->get_left_controller_index());
+    glm::vec3 left_hand_position = vr->get_controller_position_with_offset(VR::Side::LEFT);
+    glm::quat left_hand_rotation = vr->get_controller_rotation_with_offset(VR::Side::LEFT); // vr->get_aim_rotation(vr->get_left_controller_index());
 
     if (m_attach_lerp_enabled->value()) {
         auto spherical_distance_left = glm::dot(left_hand_rotation, m_last_left_aim_rotation);

--- a/src/mods/UObjectHook.cpp
+++ b/src/mods/UObjectHook.cpp
@@ -430,8 +430,8 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
         return;
     }
 
-    glm::vec3 right_hand_position = vr->get_controller_position_with_offset(VR::Side::RIGHT);
-    glm::quat right_hand_rotation = vr->get_controller_rotation_with_offset(VR::Side::RIGHT);//  vr->get_aim_rotation(vr->get_right_controller_index());
+    glm::vec3 right_hand_position = vr->get_controller_position_with_offset(VRRuntime::Hand::RIGHT);
+    glm::quat right_hand_rotation = vr->get_controller_rotation_with_offset(VRRuntime::Hand::RIGHT);//  vr->get_aim_rotation(vr->get_right_controller_index());
 
     const float lerp_speed = m_attach_lerp_speed->value() * m_last_delta_time;
 
@@ -452,8 +452,8 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
     const auto original_right_hand_rotation = right_hand_rotation;
     const auto original_right_hand_position = right_hand_position - hmd_origin;
 
-    glm::vec3 left_hand_position = vr->get_controller_position_with_offset(VR::Side::LEFT);
-    glm::quat left_hand_rotation = vr->get_controller_rotation_with_offset(VR::Side::LEFT); // vr->get_aim_rotation(vr->get_left_controller_index());
+    glm::vec3 left_hand_position = vr->get_controller_position_with_offset(VRRuntime::Hand::LEFT);
+    glm::quat left_hand_rotation = vr->get_controller_rotation_with_offset(VRRuntime::Hand::LEFT); // vr->get_aim_rotation(vr->get_left_controller_index());
 
     if (m_attach_lerp_enabled->value()) {
         auto spherical_distance_left = glm::dot(left_hand_rotation, m_last_left_aim_rotation);

--- a/src/mods/UObjectHook.cpp
+++ b/src/mods/UObjectHook.cpp
@@ -431,7 +431,7 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
     }
 
     glm::vec3 right_hand_position = vr->get_grip_position(vr->get_right_controller_index());
-    glm::quat right_hand_rotation = vr->get_aim_rotation(vr->get_right_controller_index());
+    glm::quat right_hand_rotation = vr->get_right_controller_aim_rotation_with_offset();//  vr->get_aim_rotation(vr->get_right_controller_index());
 
     const float lerp_speed = m_attach_lerp_speed->value() * m_last_delta_time;
 
@@ -453,7 +453,7 @@ void UObjectHook::tick_attachments(Rotator<float>* view_rotation, const float wo
     const auto original_right_hand_position = right_hand_position - hmd_origin;
 
     glm::vec3 left_hand_position = vr->get_grip_position(vr->get_left_controller_index());
-    glm::quat left_hand_rotation = vr->get_aim_rotation(vr->get_left_controller_index());
+    glm::quat left_hand_rotation = vr->get_left_controller_aim_rotation_with_offset(); // vr->get_aim_rotation(vr->get_left_controller_index());
 
     if (m_attach_lerp_enabled->value()) {
         auto spherical_distance_left = glm::dot(left_hand_rotation, m_last_left_aim_rotation);

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2392,12 +2392,13 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
 
             m_aim_speed->draw("Speed");
             m_aim_interp->draw("Smoothing");
-            m_left_aim_offset_x_degrees->draw("Left Controller X Rotation");
-            m_left_aim_offset_y_degrees->draw("Left Controller Y Rotation");
-            m_left_aim_offset_z_degrees->draw("Left Controller Z Rotation");
-            m_right_aim_offset_x_degrees->draw("Right Controller X Rotation");
-            m_right_aim_offset_y_degrees->draw("Right Controller Y Rotation");
-            m_right_aim_offset_z_degrees->draw("Right Controller Z Rotation");
+            // TODO: the labels describe the effect correctly, rename the variables etc to match
+            m_left_aim_offset_x_degrees->draw("Left Controller Yaw");
+            m_left_aim_offset_y_degrees->draw("Left Controller Roll");
+            m_left_aim_offset_z_degrees->draw("Left Controller Pitch");
+            m_right_aim_offset_x_degrees->draw("Right Controller Yaw");
+            m_right_aim_offset_y_degrees->draw("Right Controller Roll");
+            m_right_aim_offset_z_degrees->draw("Right Controller Pitch");
             m_aim_modify_player_control_rotation->draw("Modify Player Control Rotation");
             ImGui::SameLine();
             m_aim_use_pawn_control_rotation->draw("Use Pawn Control Rotation");

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2392,19 +2392,50 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
 
             m_aim_speed->draw("Speed");
             m_aim_interp->draw("Smoothing");
-            // TODO: the labels describe the effect correctly, rename the variables etc to match
-            // and convert to SliderFloat3 compact layout
-            m_left_aim_offset_x_degrees->draw("Left Controller Yaw");
-            m_left_aim_offset_y_degrees->draw("Left Controller Roll");
-            m_left_aim_offset_z_degrees->draw("Left Controller Pitch");
-            m_right_aim_offset_x_degrees->draw("Right Controller Yaw");
-            m_right_aim_offset_y_degrees->draw("Right Controller Roll");
-            m_right_aim_offset_z_degrees->draw("Right Controller Pitch");
+
             m_aim_modify_player_control_rotation->draw("Modify Player Control Rotation");
             ImGui::SameLine();
             m_aim_use_pawn_control_rotation->draw("Use Pawn Control Rotation");
 
             m_aim_multiplayer_support->draw("Multiplayer Support");
+
+            ImGui::TreePop();
+        }
+
+        ImGui::SetNextItemOpen(true, ImGuiCond_::ImGuiCond_Once);
+        if (ImGui::TreeNode("Aim Offsets")) {
+            ImGui::TextWrapped("Motion Controller Rotation");
+
+            float left_controller_rotation_offset[] = {m_left_controller_rotation_offset_x->value(),
+                m_left_controller_rotation_offset_y->value(), m_left_controller_rotation_offset_z->value()};
+            if (ImGui::SliderFloat3("Left Rotation Offset", left_controller_rotation_offset, -180.0f, 180.0f)) {
+                m_left_controller_rotation_offset_x->value() = left_controller_rotation_offset[0];
+                m_left_controller_rotation_offset_y->value() = left_controller_rotation_offset[1];
+                m_left_controller_rotation_offset_z->value() = left_controller_rotation_offset[2];
+            }
+            float right_controller_rotation_offset[] = {m_right_controller_rotation_offset_x->value(),
+                m_right_controller_rotation_offset_y->value(), m_right_controller_rotation_offset_z->value()};
+            if (ImGui::SliderFloat3("Right Rotation Offset", right_controller_rotation_offset, -180.0f, 180.0f)) {
+                m_right_controller_rotation_offset_x->value() = right_controller_rotation_offset[0];
+                m_right_controller_rotation_offset_y->value() = right_controller_rotation_offset[1];
+                m_right_controller_rotation_offset_z->value() = right_controller_rotation_offset[2];
+            }
+
+            ImGui::TextWrapped("Motion Controller Position");
+            float left_controller_position_offset[] = {m_left_controller_position_offset_x->value(),
+                m_left_controller_position_offset_y->value(), m_left_controller_position_offset_z->value()};
+            if (ImGui::SliderFloat3("Left Position Offset", left_controller_position_offset, -1.0f, 1.0f)) {
+                m_left_controller_position_offset_x->value() = left_controller_position_offset[0];
+                m_left_controller_position_offset_y->value() = left_controller_position_offset[1];
+                m_left_controller_position_offset_z->value() = left_controller_position_offset[2];
+            }
+            float right_controller_position_offset[] = {m_right_controller_position_offset_x->value(),
+                m_right_controller_position_offset_y->value(), m_right_controller_position_offset_z->value()};
+            if (ImGui::SliderFloat3("Right Position Offset", right_controller_position_offset, -1.0f, 1.0f)) {
+                m_right_controller_position_offset_x->value() = right_controller_position_offset[0];
+                m_right_controller_position_offset_y->value() = right_controller_position_offset[1];
+                m_right_controller_position_offset_z->value() = right_controller_position_offset[2];
+            }
 
             ImGui::TreePop();
         }

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2376,7 +2376,9 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
         ImGui::SetNextItemOpen(true, ImGuiCond_::ImGuiCond_Once);
         if (ImGui::TreeNode("Controller")) {
             m_joystick_deadzone->draw("VR Joystick Deadzone");
-            m_controller_pitch_offset->draw("Controller Pitch Offset");
+
+            // JB: pitch offset is settable in the separate 'offsets' submenu
+            // m_controller_pitch_offset->draw("Controller Pitch Offset");
 
             m_dpad_shifting->draw("DPad Shifting");
             ImGui::SameLine();
@@ -2443,7 +2445,6 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
                 m_left_controller_position_offset_y->value() = 0.0f;
                 m_left_controller_position_offset_z->value() = 0.0f;
             }
-            ImGui::NewLine();
             float right_controller_position_offset[] = {m_right_controller_position_offset_x->value(),
                 m_right_controller_position_offset_y->value(), m_right_controller_position_offset_z->value()};
             if (ImGui::SliderFloat3("Right Position", right_controller_position_offset, -1.0f, 1.0f)) {

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2413,12 +2413,22 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
                 m_left_controller_rotation_offset_y->value() = left_controller_rotation_offset[1];
                 m_left_controller_rotation_offset_z->value() = left_controller_rotation_offset[2];
             }
+            if (ImGui::Button("Reset Left Rotation Offsets")) {
+                m_left_controller_rotation_offset_x->value() = 0.0f;
+                m_left_controller_rotation_offset_y->value() = 0.0f;
+                m_left_controller_rotation_offset_z->value() = 0.0f;
+            }
             float right_controller_rotation_offset[] = {m_right_controller_rotation_offset_x->value(),
                 m_right_controller_rotation_offset_y->value(), m_right_controller_rotation_offset_z->value()};
             if (ImGui::SliderFloat3("Right Rotation Offset", right_controller_rotation_offset, -180.0f, 180.0f)) {
                 m_right_controller_rotation_offset_x->value() = right_controller_rotation_offset[0];
                 m_right_controller_rotation_offset_y->value() = right_controller_rotation_offset[1];
                 m_right_controller_rotation_offset_z->value() = right_controller_rotation_offset[2];
+            }
+            if (ImGui::Button("Reset Right Rotation Offsets")) {
+                m_right_controller_rotation_offset_x->value() = 0.0f;
+                m_right_controller_rotation_offset_y->value() = 0.0f;
+                m_right_controller_rotation_offset_z->value() = 0.0f;
             }
 
             ImGui::TextWrapped("Motion Controller Position");
@@ -2429,6 +2439,11 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
                 m_left_controller_position_offset_y->value() = left_controller_position_offset[1];
                 m_left_controller_position_offset_z->value() = left_controller_position_offset[2];
             }
+            if (ImGui::Button("Reset Left Position Offsets")) {
+                m_left_controller_position_offset_x->value() = 0.0f;
+                m_left_controller_position_offset_y->value() = 0.0f;
+                m_left_controller_position_offset_z->value() = 0.0f;
+            }
             float right_controller_position_offset[] = {m_right_controller_position_offset_x->value(),
                 m_right_controller_position_offset_y->value(), m_right_controller_position_offset_z->value()};
             if (ImGui::SliderFloat3("Right Position Offset", right_controller_position_offset, -1.0f, 1.0f)) {
@@ -2436,7 +2451,11 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
                 m_right_controller_position_offset_y->value() = right_controller_position_offset[1];
                 m_right_controller_position_offset_z->value() = right_controller_position_offset[2];
             }
-
+            if (ImGui::Button("Reset Right Position Offsets")) {
+                m_right_controller_position_offset_x->value() = 0.0f;
+                m_right_controller_position_offset_y->value() = 0.0f;
+                m_right_controller_position_offset_z->value() = 0.0f;
+            }
             ImGui::TreePop();
         }
 

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2392,7 +2392,12 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
 
             m_aim_speed->draw("Speed");
             m_aim_interp->draw("Smoothing");
-
+            m_left_aim_offset_x_degrees->draw("Left Controller X Rotation");
+            m_left_aim_offset_y_degrees->draw("Left Controller Y Rotation");
+            m_left_aim_offset_z_degrees->draw("Left Controller Z Rotation");
+            m_right_aim_offset_x_degrees->draw("Right Controller X Rotation");
+            m_right_aim_offset_y_degrees->draw("Right Controller Y Rotation");
+            m_right_aim_offset_z_degrees->draw("Right Controller Z Rotation");
             m_aim_modify_player_control_rotation->draw("Modify Player Control Rotation");
             ImGui::SameLine();
             m_aim_use_pawn_control_rotation->draw("Use Pawn Control Rotation");

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2402,56 +2402,53 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
             ImGui::TreePop();
         }
 
-        ImGui::SetNextItemOpen(true, ImGuiCond_::ImGuiCond_Once);
-        if (ImGui::TreeNode("Aim Offsets")) {
-            ImGui::TextWrapped("Motion Controller Rotation");
-
+        if (ImGui::TreeNode("Motion Controller Aim Offsets")) {
             float left_controller_rotation_offset[] = {m_left_controller_rotation_offset_x->value(),
                 m_left_controller_rotation_offset_y->value(), m_left_controller_rotation_offset_z->value()};
-            if (ImGui::SliderFloat3("Left Rotation Offset", left_controller_rotation_offset, -180.0f, 180.0f)) {
+            if (ImGui::SliderFloat3("Left Rotation", left_controller_rotation_offset, -180.0f, 180.0f)) {
                 m_left_controller_rotation_offset_x->value() = left_controller_rotation_offset[0];
                 m_left_controller_rotation_offset_y->value() = left_controller_rotation_offset[1];
                 m_left_controller_rotation_offset_z->value() = left_controller_rotation_offset[2];
             }
-            if (ImGui::Button("Reset Left Rotation Offsets")) {
+            if (ImGui::Button("Reset Left Rotation")) {
                 m_left_controller_rotation_offset_x->value() = 0.0f;
                 m_left_controller_rotation_offset_y->value() = 0.0f;
                 m_left_controller_rotation_offset_z->value() = 0.0f;
             }
             float right_controller_rotation_offset[] = {m_right_controller_rotation_offset_x->value(),
                 m_right_controller_rotation_offset_y->value(), m_right_controller_rotation_offset_z->value()};
-            if (ImGui::SliderFloat3("Right Rotation Offset", right_controller_rotation_offset, -180.0f, 180.0f)) {
+            if (ImGui::SliderFloat3("Right Rotation", right_controller_rotation_offset, -180.0f, 180.0f)) {
                 m_right_controller_rotation_offset_x->value() = right_controller_rotation_offset[0];
                 m_right_controller_rotation_offset_y->value() = right_controller_rotation_offset[1];
                 m_right_controller_rotation_offset_z->value() = right_controller_rotation_offset[2];
             }
-            if (ImGui::Button("Reset Right Rotation Offsets")) {
+            if (ImGui::Button("Reset Right Rotation")) {
                 m_right_controller_rotation_offset_x->value() = 0.0f;
                 m_right_controller_rotation_offset_y->value() = 0.0f;
                 m_right_controller_rotation_offset_z->value() = 0.0f;
             }
-
-            ImGui::TextWrapped("Motion Controller Position");
+            ImGui::NewLine();
             float left_controller_position_offset[] = {m_left_controller_position_offset_x->value(),
                 m_left_controller_position_offset_y->value(), m_left_controller_position_offset_z->value()};
-            if (ImGui::SliderFloat3("Left Position Offset", left_controller_position_offset, -1.0f, 1.0f)) {
+            if (ImGui::SliderFloat3("Left Position", left_controller_position_offset, -1.0f, 1.0f)) {
                 m_left_controller_position_offset_x->value() = left_controller_position_offset[0];
                 m_left_controller_position_offset_y->value() = left_controller_position_offset[1];
                 m_left_controller_position_offset_z->value() = left_controller_position_offset[2];
             }
-            if (ImGui::Button("Reset Left Position Offsets")) {
+            if (ImGui::Button("Reset Left Position")) {
                 m_left_controller_position_offset_x->value() = 0.0f;
                 m_left_controller_position_offset_y->value() = 0.0f;
                 m_left_controller_position_offset_z->value() = 0.0f;
             }
+            ImGui::NewLine();
             float right_controller_position_offset[] = {m_right_controller_position_offset_x->value(),
                 m_right_controller_position_offset_y->value(), m_right_controller_position_offset_z->value()};
-            if (ImGui::SliderFloat3("Right Position Offset", right_controller_position_offset, -1.0f, 1.0f)) {
+            if (ImGui::SliderFloat3("Right Position", right_controller_position_offset, -1.0f, 1.0f)) {
                 m_right_controller_position_offset_x->value() = right_controller_position_offset[0];
                 m_right_controller_position_offset_y->value() = right_controller_position_offset[1];
                 m_right_controller_position_offset_z->value() = right_controller_position_offset[2];
             }
-            if (ImGui::Button("Reset Right Position Offsets")) {
+            if (ImGui::Button("Reset Right Position")) {
                 m_right_controller_position_offset_x->value() = 0.0f;
                 m_right_controller_position_offset_y->value() = 0.0f;
                 m_right_controller_position_offset_z->value() = 0.0f;

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2393,6 +2393,7 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
             m_aim_speed->draw("Speed");
             m_aim_interp->draw("Smoothing");
             // TODO: the labels describe the effect correctly, rename the variables etc to match
+            // and convert to SliderFloat3 compact layout
             m_left_aim_offset_x_degrees->draw("Left Controller Yaw");
             m_left_aim_offset_y_degrees->draw("Left Controller Roll");
             m_left_aim_offset_z_degrees->draw("Left Controller Pitch");

--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -173,6 +173,34 @@ public:
         return get_rotation(index, true);
     }
 
+    Matrix4x4f get_left_controller_aim_rotation_with_offset() {
+        float x_offset_degrees = get_left_aim_offset_x_degrees();
+        float y_offset_degrees = get_left_aim_offset_y_degrees();
+        float z_offset_degrees = get_left_aim_offset_z_degrees();
+        // if there's no offsets defined, return the original:
+        auto const rotation = get_rotation(get_left_controller_index(), false);
+        if (x_offset_degrees == 0 && y_offset_degrees == 0 && z_offset_degrees == 0) {
+            return rotation;
+        } else {
+            auto const requested_rotation_offset = utility::math::ue_rotation_matrix(glm::vec3{x_offset_degrees, y_offset_degrees, -z_offset_degrees});
+            return rotation * requested_rotation_offset;
+        }
+    }
+
+    Matrix4x4f get_right_controller_aim_rotation_with_offset() {
+        float x_offset_degrees = get_right_aim_offset_x_degrees();
+        float y_offset_degrees = get_right_aim_offset_y_degrees();
+        float z_offset_degrees = get_right_aim_offset_z_degrees();
+        // if there's no offsets defined, return the original:
+        auto const rotation = get_rotation(get_right_controller_index(), false);
+        if (x_offset_degrees == 0 && y_offset_degrees == 0 && z_offset_degrees == 0) {
+            return rotation;
+        } else {
+            auto const requested_rotation_offset = utility::math::ue_rotation_matrix(glm::vec3{x_offset_degrees, y_offset_degrees, -z_offset_degrees});
+            return rotation * requested_rotation_offset;
+        }
+    }
+
     Matrix4x4f get_aim_rotation(uint32_t index) const {
         return get_rotation(index, false);
     }
@@ -446,6 +474,30 @@ public:
 
     float get_aim_speed() const {
         return m_aim_speed->value();
+    }
+
+    float get_left_aim_offset_x_degrees() const {
+        return m_left_aim_offset_x_degrees->value();
+    }
+
+    float get_left_aim_offset_y_degrees() const {
+        return m_left_aim_offset_y_degrees->value();
+    }
+
+    float get_left_aim_offset_z_degrees() const {
+        return m_left_aim_offset_z_degrees->value();
+    }
+    
+    float get_right_aim_offset_x_degrees() const {
+        return m_right_aim_offset_x_degrees->value();
+    }
+
+    float get_right_aim_offset_y_degrees() const {
+        return m_right_aim_offset_y_degrees->value();
+    }
+
+    float get_right_aim_offset_z_degrees() const {
+        return m_right_aim_offset_z_degrees->value();
     }
     
     bool is_aim_multiplayer_support_enabled() const {
@@ -800,7 +852,13 @@ private:
     const ModToggle::Ptr m_aim_modify_player_control_rotation{ ModToggle::create(generate_name("AimModifyPlayerControlRotation"), false) };
     const ModToggle::Ptr m_aim_multiplayer_support{ ModToggle::create(generate_name("AimMPSupport"), false) };
     const ModToggle::Ptr m_aim_interp{ ModToggle::create(generate_name("AimInterp"), true, true) };
-    const ModSlider::Ptr m_aim_speed{ ModSlider::create(generate_name("AimSpeed"), 0.01f, 25.0f, 15.0f) };
+    const ModSlider::Ptr m_aim_speed{ModSlider::create(generate_name("AimSpeed"), 0.01f, 25.0f, 15.0f)};
+    const ModSlider::Ptr m_left_aim_offset_x_degrees{ModSlider::create(generate_name("LeftAimOffsetXDegrees"), -90.0f, 90.0f, 0.0f)};
+    const ModSlider::Ptr m_left_aim_offset_y_degrees{ModSlider::create(generate_name("LeftAimOffsetYDegrees"), -90.0f, 90.0f, 0.0f)};
+    const ModSlider::Ptr m_left_aim_offset_z_degrees{ModSlider::create(generate_name("LeftAimOffsetZDegrees"), -90.0f, 90.0f, 0.0f)};
+    const ModSlider::Ptr m_right_aim_offset_x_degrees{ModSlider::create(generate_name("RightAimOffsetXDegrees"), -90.0f, 90.0f, 0.0f)};
+    const ModSlider::Ptr m_right_aim_offset_y_degrees{ModSlider::create(generate_name("RightAimOffsetYDegrees"), -90.0f, 90.0f, 0.0f)};
+    const ModSlider::Ptr m_right_aim_offset_z_degrees{ModSlider::create(generate_name("RightAimOffsetZDegrees"), -90.0f, 90.0f, 0.0f)};
     const ModToggle::Ptr m_dpad_shifting{ ModToggle::create(generate_name("DPadShifting"), true) };
     const ModCombo::Ptr m_dpad_shifting_method{ ModCombo::create(generate_name("DPadShiftingMethod"), s_dpad_method_names, DPadMethod::RIGHT_TOUCH) };
     
@@ -914,6 +972,12 @@ private:
         *m_aim_modify_player_control_rotation,
         *m_aim_multiplayer_support,
         *m_aim_speed,
+        *m_left_aim_offset_x_degrees,
+        *m_left_aim_offset_y_degrees,
+        *m_left_aim_offset_z_degrees,
+        *m_right_aim_offset_x_degrees,
+        *m_right_aim_offset_y_degrees,
+        *m_right_aim_offset_z_degrees,
         *m_aim_interp,
         *m_dpad_shifting,
         *m_dpad_shifting_method,

--- a/src/mods/vr/IXRTrackingSystemHook.cpp
+++ b/src/mods/vr/IXRTrackingSystemHook.cpp
@@ -1746,8 +1746,8 @@ void IXRTrackingSystemHook::update_view_rotation(sdk::UObject* reference_obj, Ro
         if (aim_type == VR::AimMethod::RIGHT_CONTROLLER || aim_type == VR::AimMethod::LEFT_CONTROLLER) {
             const auto controller_index = aim_type == VR::AimMethod::RIGHT_CONTROLLER ? vr->get_right_controller_index() : vr->get_left_controller_index();
             og_controller_rot = aim_type == VR::AimMethod::RIGHT_CONTROLLER ?
-                    glm::quat{ vr->get_controller_rotation_with_offset(VR::Side::RIGHT) } :
-                    glm::quat{ vr->get_controller_rotation_with_offset(VR::Side::LEFT) }; // glm::quat{vr->get_aim_rotation(controller_index)};
+                    glm::quat{ vr->get_controller_rotation_with_offset(VRRuntime::Hand::RIGHT) } :
+                    glm::quat{ vr->get_controller_rotation_with_offset(VRRuntime::Hand::LEFT) }; // glm::quat{vr->get_aim_rotation(controller_index)};
             og_controller_pos = glm::vec3{vr->get_aim_position(controller_index)};
             right_controller_forward = og_controller_rot * glm::vec3{0.0f, 0.0f, 1.0f};
         } else if (aim_type == VR::AimMethod::TWO_HANDED_RIGHT) { // two handed modes are for imitating rifle aiming

--- a/src/mods/vr/IXRTrackingSystemHook.cpp
+++ b/src/mods/vr/IXRTrackingSystemHook.cpp
@@ -1745,7 +1745,10 @@ void IXRTrackingSystemHook::update_view_rotation(sdk::UObject* reference_obj, Ro
 
         if (aim_type == VR::AimMethod::RIGHT_CONTROLLER || aim_type == VR::AimMethod::LEFT_CONTROLLER) {
             const auto controller_index = aim_type == VR::AimMethod::RIGHT_CONTROLLER ? vr->get_right_controller_index() : vr->get_left_controller_index();
-            og_controller_rot = glm::quat{vr->get_aim_rotation(controller_index)};
+        og_controller_rot =
+            aim_type == VR::AimMethod::RIGHT_CONTROLLER ?
+                glm::quat{ vr->get_right_controller_aim_rotation_with_offset() } :
+                glm::quat{ vr->get_left_controller_aim_rotation_with_offset() }; // glm::quat{vr->get_aim_rotation(controller_index)};
             og_controller_pos = glm::vec3{vr->get_aim_position(controller_index)};
             right_controller_forward = og_controller_rot * glm::vec3{0.0f, 0.0f, 1.0f};
         } else if (aim_type == VR::AimMethod::TWO_HANDED_RIGHT) { // two handed modes are for imitating rifle aiming

--- a/src/mods/vr/IXRTrackingSystemHook.cpp
+++ b/src/mods/vr/IXRTrackingSystemHook.cpp
@@ -1745,10 +1745,9 @@ void IXRTrackingSystemHook::update_view_rotation(sdk::UObject* reference_obj, Ro
 
         if (aim_type == VR::AimMethod::RIGHT_CONTROLLER || aim_type == VR::AimMethod::LEFT_CONTROLLER) {
             const auto controller_index = aim_type == VR::AimMethod::RIGHT_CONTROLLER ? vr->get_right_controller_index() : vr->get_left_controller_index();
-        og_controller_rot =
-            aim_type == VR::AimMethod::RIGHT_CONTROLLER ?
-                glm::quat{ vr->get_right_controller_aim_rotation_with_offset() } :
-                glm::quat{ vr->get_left_controller_aim_rotation_with_offset() }; // glm::quat{vr->get_aim_rotation(controller_index)};
+            og_controller_rot = aim_type == VR::AimMethod::RIGHT_CONTROLLER ?
+                    glm::quat{ vr->get_controller_rotation_with_offset(VR::Side::RIGHT) } :
+                    glm::quat{ vr->get_controller_rotation_with_offset(VR::Side::LEFT) }; // glm::quat{vr->get_aim_rotation(controller_index)};
             og_controller_pos = glm::vec3{vr->get_aim_position(controller_index)};
             right_controller_forward = og_controller_rot * glm::vec3{0.0f, 0.0f, 1.0f};
         } else if (aim_type == VR::AimMethod::TWO_HANDED_RIGHT) { // two handed modes are for imitating rifle aiming


### PR DESCRIPTION
Rotation offsets (all axes) replace the Controller Pitch slider recently added (commented out of the UI code)

Position offsets are relative to the controller's (offset) rotation - like it's on a stick attached to the 'real' controller position. Can't think of a use case for this but maybe someone will find it useful if their controller is attached to an object, with the user holding the object instead of the controller
