### PR TITLE
Fix: Lua can generate wrong code when _ENV is <const>

### DIFF
--- a/dependencies/lua/src/lparser.c
+++ b/dependencies/lua/src/lparser.c
@@ -468,6 +468,7 @@ static void singlevar (LexState *ls, expdesc *var) {
     expdesc key;
     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
     lua_assert(var->k != VVOID);  /* this one must exist */
+    luaK_exp2anyregup(fs, var);  /* but could be a constant */
     codestring(&key, varname);  /* key is variable name */
     luaK_indexed(fs, var, &key);  /* env[varname] */
   }


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in singlevar() that was cloned from lua but did not receive the security patch. The original issue was reported and fixed under https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2022-28805
https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa