### PR TITLE
Update FoV dynamically when HMD FoV changes

### DIFF
--- a/src/mods/vr/runtimes/OpenXR.cpp
+++ b/src/mods/vr/runtimes/OpenXR.cpp
@@ -553,9 +553,13 @@ VRRuntime::Error OpenXR::update_matrices(float nearz, float farz) {
         };
     };
 
+    static long int frame_count = -1;
+    frame_count++;
+
+
     // if we've not yet derived an eye projection matrix, or we've changed the projection, derive it here
     // Hacky way to check for an uninitialised eye matrix - is there something better, is this necessary?
-    if (this->should_recalculate_eye_projections || this->last_eye_matrix_nearz != nearz || this->projections[0][2][3] == 0) {
+    if (this->should_recalculate_eye_projections || this->last_eye_matrix_nearz != nearz || this->projections[0][2][3] == 0 || frame_count % 100 == 0) {
         // deriving the texture bounds when modifying projections requires left and right raw projections so get them all before we start:
         std::unique_lock __{this->eyes_mtx};
         const auto& left_fov = this->views[0].fov;

--- a/src/mods/vr/runtimes/OpenXR.hpp
+++ b/src/mods/vr/runtimes/OpenXR.hpp
@@ -212,6 +212,9 @@ public:
     std::vector<XrView> views{};
     std::vector<XrView> stage_views{};
 
+    std::array<XrFovf, 2> last_fovs{}; 
+
+
     //std::deque<std::vector<XrView>> stage_view_queue{};
     struct PipelineState {
         XrFrameState frame_state{XR_TYPE_FRAME_STATE};


### PR DESCRIPTION
https://github.com/praydog/UEVR/issues/371

Note that this is a very simple and awkward fix of the issue and I dont think it is good to merge yet. I need some help improving it.

Key idea: OpenXR::update_matrices() is, i guess, called every frame. The projection matrix(for intricsic parameters) update are somehow skipped in the function. And since convergence settings are effectly changing the intricsic parameters, we got convergence settings ignored in uevr.  So to fix it, we just force the projection matrix update every 100frames (in case it is expensive, which looks unlikely). 

To improve it, I have 2 ideas. 
 - (A) we force the projection matrix update every call of OpenXR::update_matrices(). But it can have some cost
 - (B) we cache this->views[0].fov and this->views[1].fov. if this call's these variables are different from our cached version, we update the projection matrix.