### PR TITLE
replace some auto types with signed types

### DIFF
--- a/src/mods/vr/FFakeStereoRenderingHook.cpp
+++ b/src/mods/vr/FFakeStereoRenderingHook.cpp
@@ -804,10 +804,10 @@ bool FFakeStereoRenderingHook::standard_fake_stereo_hook(uintptr_t vtable) {
         return false;
     }
 
-    unsigned long long rendertexture_fn_vtable_index = (*rendertexture_fn_vtable_middle - vtable) / sizeof(uintptr_t);
+    signed long long rendertexture_fn_vtable_index = (*rendertexture_fn_vtable_middle - vtable) / sizeof(uintptr_t);
     SPDLOG_INFO("RenderTexture_RenderThread VTable Middle: {} {:x}", rendertexture_fn_vtable_index, (uintptr_t)*rendertexture_fn_vtable_middle);
 
-    unsigned long long render_target_manager_vtable_index = rendertexture_fn_vtable_index + 1 + (2 * (size_t)is_4_18_or_lower);
+    signed long long render_target_manager_vtable_index = rendertexture_fn_vtable_index + 1 + (2 * (size_t)is_4_18_or_lower);
 
     // verify first that the render target manager index is returning a null pointer
     // and if not, scan forward until we run into a vfunc that returns a null pointer
@@ -827,7 +827,7 @@ bool FFakeStereoRenderingHook::standard_fake_stereo_hook(uintptr_t vtable) {
             }
 
             if (sdk::is_vfunc_pattern(*(uintptr_t*)get_render_target_manager_func_ptr, "33 C0") || (!uses_33_c0 && sdk::is_vfunc_pattern(*(uintptr_t*)get_render_target_manager_func_ptr, "31 C0"))) {
-                const unsigned long long distance_from_rendertexture_fn = render_target_manager_vtable_index - rendertexture_fn_vtable_index;
+                const signed long long distance_from_rendertexture_fn = render_target_manager_vtable_index - rendertexture_fn_vtable_index;
 
                 // means it's 4.17 I think. 12 means 4.11.
                 if (distance_from_rendertexture_fn == 10 || distance_from_rendertexture_fn == 11 || distance_from_rendertexture_fn == 12) {


### PR DESCRIPTION
the compiler seems to be chosing unsigned types for some of these variables, resulting in unexpected values when they're later used in simple arithmetic operations leading to crashes on injection. Note that the VS2022 compiler seems to be more consistent here in choosing signed types, but I've not established a pattern.

see https://github.com/praydog/UEVR/issues/373
