### PR TITLE
fix: date and time

### DIFF
--- a/MakeCommitHash.bat
+++ b/MakeCommitHash.bat
@@ -7,10 +7,10 @@ exit /b 0
 
 FOR /F "tokens=*" %%g IN ('git rev-parse HEAD') DO (SET UEVR_COMMIT_HASH=%%g)
 
-FOR /F "tokens=*" %%t IN ('git describe --tags --abbrev^=0') DO (SET UEVR_TAG=%%t)
+FOR /F "tokens=*" %%t IN ('git describe --tags --always --abbrev^=0') DO (SET UEVR_TAG=%%t)
 IF "%UEVR_TAG%"=="" (SET UEVR_TAG=no_tag)
 
-FOR /F "tokens=*" %%c IN ('git describe --tags --long') DO (
+FOR /F "tokens=*" %%c IN ('git describe --tags --always --long') DO (
 FOR /F "tokens=1,2 delims=-" %%a IN ("%%c") DO (
 SET UEVR_TAG_LONG=%%a
 SET UEVR_COMMITS_PAST_TAG=%%b
@@ -24,7 +24,7 @@ FOR /F "tokens=*" %%b IN ('git rev-parse --abbrev-ref HEAD') DO (SET UEVR_BRANCH
 FOR /F "tokens=*" %%n IN ('git rev-list --count HEAD') DO (SET UEVR_TOTAL_COMMITS=%%n)
 IF "%UEVR_TOTAL_COMMITS%"=="" (SET UEVR_TOTAL_COMMITS=0)
 
-FOR /F "tokens=2 delims==" %%a IN ('wmic OS get localdatetime /value') DO (
+FOR /F "tokens=*" %%a IN ('powershell -NoProfile -Command "Get-Date -Format yyyyMMddHHmmss"') DO (
 SET datetime=%%a
 )
 


### PR DESCRIPTION
Update MakeCommitHash.bat to remove wmic and use 'always' flag for robustness, as your commit hash date/time stamp specifically has been failing to generate for a few months now. same patch was applied to REFramework in https://github.com/praydog/REFramework/pull/1421


before change, while compiling backend, in log:
  Generating commit hash...
  'wmic' is not recognized as an internal or external command,
  operable program or batch file.
  Building Custom Rule D:/a/UEVR/UEVR/CMakeLists.txt
  
  
  after change:
  no errors