### PR TITLE
Fixed bug with global dir using unicode characters

### DIFF
--- a/src/Framework.cpp
+++ b/src/Framework.cpp
@@ -1002,7 +1002,8 @@ void Framework::save_config() {
         mod->on_config_save(cfg);
     }
 
-    if (!cfg.save(get_persistent_dir("config.txt").string())) {
+    auto path_u8 = get_persistent_dir("config.txt").u8string();
+    if (!cfg.save(std::string(path_u8.begin(), path_u8.end()))) {
         spdlog::info("Failed to save config");
         return;
     }

--- a/src/Mods.cpp
+++ b/src/Mods.cpp
@@ -54,7 +54,8 @@ std::optional<std::string> Mods::on_initialize_d3d_thread() const {
 }
 
 void Mods::reload_config(bool set_defaults) const {
-    utility::Config cfg{ Framework::get_persistent_dir("config.txt").string() };
+    auto path_u8 = Framework::get_persistent_dir("config.txt").u8string();
+    utility::Config cfg{ std::string(path_u8.begin(), path_u8.end()) };
 
     for (auto& mod : m_mods) {
         spdlog::info("{:s}::on_config_load()", mod->get_name().data());


### PR DESCRIPTION
There was a bug where if user had some weird character in their %appdata% username, UEVR was unable to load config.txt or save changes to config.txt.  It was caused by sending a string to kananalib's config save. Even though it widened the string, the damage was done. This solves it by sending a u8string instead.  Done for both load and save.  User reported that the fix works.

a swedish name with the letter ö as in grönbek