### PR TITLE
UI: Use DragFloat3 for Camera Offset controls

### DIFF
--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2522,10 +2522,13 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
         ImGui::SetNextItemOpen(true, ImGuiCond_::ImGuiCond_Once);
         if (ImGui::TreeNode("Camera Freeze")) {
             float camera_offset[] = {m_camera_forward_offset->value(), m_camera_right_offset->value(), m_camera_up_offset->value()};
-            if (ImGui::SliderFloat3("Camera Offset", camera_offset, -4000.0f, 4000.0f)) {
+            if (ImGui::DragFloat3("Camera Offset", camera_offset, 1.0f, -4000.0f, 4000.0f)) {
                 m_camera_forward_offset->value() = camera_offset[0];
                 m_camera_right_offset->value() = camera_offset[1];
                 m_camera_up_offset->value() = camera_offset[2];
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Drag to adjust. Hold Shift while dragging for fine adjustment.\nCtrl+Click to type a value directly.\nArrow keys available when editing.");
             }
 
             for (auto i = 0; i < m_camera_datas.size(); ++i) {

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -2522,13 +2522,13 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
         ImGui::SetNextItemOpen(true, ImGuiCond_::ImGuiCond_Once);
         if (ImGui::TreeNode("Camera Freeze")) {
             float camera_offset[] = {m_camera_forward_offset->value(), m_camera_right_offset->value(), m_camera_up_offset->value()};
-            if (ImGui::DragFloat3("Camera Offset", camera_offset, 1.0f, -4000.0f, 4000.0f)) {
+            if (ImGui::DragFloat3("Camera Offset", camera_offset, 0.5f, -4000.0f, 4000.0f)) {
                 m_camera_forward_offset->value() = camera_offset[0];
                 m_camera_right_offset->value() = camera_offset[1];
                 m_camera_up_offset->value() = camera_offset[2];
             }
             if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip("Drag to adjust. Hold Shift while dragging for fine adjustment.\nCtrl+Click to type a value directly.\nArrow keys available when editing.");
+                ImGui::SetTooltip("Drag to adjust. Hold Alt while dragging for fine adjustment.\nHold Shift for faster adjustment.\nCtrl+Click to type a value directly.");
             }
 
             for (auto i = 0; i < m_camera_datas.size(); ++i) {


### PR DESCRIPTION
The Camera Offset sliders under Camera Freeze use `SliderFloat3` with a +- 4000 range,
which makes dialing in precise position values impractical - the slider moves too
coarsely to land on a specific value.

This replaces them with `DragFloat3`, which:
- Defaults to a slow drag speed (0.5 units/px) suitable for fine positioning
- Supports **Shift+drag** for faster coarse adjustment
- Supports **Alt+drag** for extra fine adjustment
- Supports **Ctrl+Click** or **Double Click** to type a value directly
- Retains the +- 4000 range

A tooltip is added to the control to surface these shortcuts for users who may not
be familiar with ImGui drag inputs.

Initial implementation by GitHub Copilot.