### PR TITLE
Fix doubled stereo image on UE 5.5/5.6 (zero-based eye index misclassified as full pass)

### DIFF
--- a/src/mods/vr/FFakeStereoRenderingHook.cpp
+++ b/src/mods/vr/FFakeStereoRenderingHook.cpp
@@ -4652,7 +4652,12 @@ __forceinline void FFakeStereoRenderingHook::calculate_stereo_view_offset(
         index_starts_from_one = false;
     }
 
-    const auto is_full_pass = view_index == 0 && !index_was_ever_two && !index_was_ever_negative;
+    // On UE5 (detected via double-precision LWC math) eye indices are always 0/1 and a genuine
+    // mono/full pass arrives as INDEX_NONE (-1), which is already ignored above. UE <= 5.4
+    // happened to send -1 (or 2) early enough to flip the flags below, but UE 5.5/5.6 only ever
+    // sends 0/1 - leaving view 0 permanently misclassified as a "full pass", which skips per-eye
+    // transforms/callbacks for one eye only and produces a heavily doubled image.
+    const auto is_full_pass = view_index == 0 && !index_was_ever_two && !index_was_ever_negative && !g_hook->m_has_double_precision;
 
     auto true_index = index_starts_from_one ? ((view_index + 1) % 2) : (view_index % 2);
     const auto has_double_precision = g_hook->m_has_double_precision;


### PR DESCRIPTION
## Problem

On UE 5.5/5.6 games, everything rendered near the camera (hands, HUD, world-space UI) appears heavily doubled with a cross-eyed effect, while distant geometry looks mostly fine. Related: #329 (UE 5.5.3 games not entering VR correctly), #368 (UE 5.6 compatibility).

## Root cause

`FFakeStereoRenderingHook::calculate_stereo_view_offset` classifies a call as a mono "full pass" via:

```cpp
const auto is_full_pass = view_index == 0 && !index_was_ever_two && !index_was_ever_negative;
```

UE <= 5.4 called `CalculateStereoViewOffset` with view index `-1` (INDEX_NONE) or `2` early on, flipping those flags so index 0 was subsequently treated as a real eye. **UE 5.5/5.6 only ever sends indices 0/1**, so view 0 stays permanently misclassified as a full pass. That skips the per-eye mod callbacks (`on_pre/post_calculate_stereo_view_offset`) and `update_hmd_state()` for one eye only, while the other eye receives the full treatment.

Measured on Satisfactory (CSS custom UE 5.6.1, 1.2 experimental branch) with first-N-call instrumentation: the two eye view locations ended up **~33.6 cm apart (including a 15.7 cm vertical offset)** instead of IPD (~6.5 cm), and the offset varied with head position. Near-field content at such disparity is unfusable - hence the double image.

## Fix

On UE5 (already detected via `m_has_double_precision` / LWC double-precision math), index 0 in a stereo pass is always a real eye - a genuine mono pass arrives as `INDEX_NONE (-1)`, which the function already filters earlier. One-line change gating the full-pass classification to non-UE5 binaries.

## Testing

- Satisfactory 1.2 experimental (CSS UE 5.6.1, D3D12, OpenXR via Virtual Desktop): double image fully resolved, eye separation verified at IPD via instrumentation, extended play session stable with the UEVR Enhancements gameplay mod.
- The remaining UE 5.6 hook warnings (Slate.DrawToVRRenderTarget cvar removed upstream, etc.) are unrelated to this fix and the slate path still works via the engine''s RDG deprecation bridge, which routes to the legacy `RenderTexture_RenderThread` vtable entry that UEVR already hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)