### PR TITLE
Add chroma key passthrough feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -790,6 +790,7 @@ list(APPEND uevr_SOURCES
 	"src/mods/pluginloader/UScriptStructFunctions.hpp"
 	"src/mods/uobjecthook/SDKDumper.hpp"
 	"src/mods/vr/CVarManager.hpp"
+	"src/mods/vr/ChromaVoid.hpp"
 	"src/mods/vr/D3D11Component.hpp"
 	"src/mods/vr/D3D12Component.hpp"
 	"src/mods/vr/FFakeStereoRenderingHook.hpp"

--- a/src/mods/VR.cpp
+++ b/src/mods/VR.cpp
@@ -6,6 +6,7 @@
 #include <dbt.h>
 
 #include <imgui.h>
+#include <glm/gtc/color_space.hpp>
 #include <utility/Module.hpp>
 #include <utility/Registry.hpp>
 #include <utility/ScopeGuard.hpp>
@@ -2407,6 +2408,29 @@ void VR::on_draw_sidebar_entry(std::string_view name) {
 
         m_overlay_component.on_draw_ui();
 
+        if (ImGui::TreeNode("Passthrough")) {
+            m_void_passthrough->draw("Chroma Key Void");
+
+            if (m_void_passthrough->value()) {
+                const auto key = get_void_key_color_srgb();
+                float col[3]{key.x, key.y, key.z};
+
+                if (ImGui::ColorEdit3("Key Color", col)) {
+                    // Clamp: CTRL+click typed input is not range-limited by ImGui.
+                    const auto to_byte = [](float v) { return (int32_t)(std::clamp(v, 0.0f, 1.0f) * 255.0f + 0.5f); };
+                    m_void_color->value() = (to_byte(col[0]) << 16) | (to_byte(col[1]) << 8) | to_byte(col[2]);
+                }
+
+                ImGui::TextWrapped("Fills the void around the 2D screen with a chroma key. Set the same color in Virtual Desktop's passthrough settings.");
+
+                if (get_runtime()->is_openvr()) {
+                    ImGui::TextWrapped("Requires an OpenXR runtime.");
+                }
+            }
+
+            ImGui::TreePop();
+        }
+
         ImGui::TreePop();
     }
 
@@ -3219,6 +3243,36 @@ void VR::set_standing_origin(const Vector4f& origin) {
     std::unique_lock _{ get_runtime()->pose_mtx };
     
     m_standing_origin = origin;
+}
+
+glm::vec4 VR::get_void_key_color_srgb() const {
+    const auto packed = (uint32_t)m_void_color->value();
+    return {
+        ((packed >> 16) & 0xFF) / 255.0f,
+        ((packed >> 8) & 0xFF) / 255.0f,
+        (packed & 0xFF) / 255.0f,
+        1.0f};
+}
+
+glm::vec4 VR::get_void_key_color_linear() const {
+    // sRGB-view render targets take linear clear values; convert so the displayed bytes match the
+    // picked key exactly (what the runtime's chroma filter sees).
+    const auto srgb = get_void_key_color_srgb();
+    return {glm::convertSRGBToLinear(glm::vec3{srgb}), 1.0f};
+}
+
+glm::vec4 VR::get_screen_capture_clear_color() const {
+    if (!is_chroma_void_active()) {
+        return {0.0f, 0.0f, 0.0f, 1.0f};
+    }
+
+    // Dashboard/system overlays dim the scene; a dimmed key no longer matches the runtime's chroma
+    // filter and shows as a solid glow -- fall back to a black void until focus returns.
+    if (m_openxr->session_state != XR_SESSION_STATE_FOCUSED) {
+        return {0.0f, 0.0f, 0.0f, 1.0f};
+    }
+
+    return get_void_key_color_linear();
 }
 
 glm::quat VR::get_rotation_offset() {

--- a/src/mods/VR.hpp
+++ b/src/mods/VR.hpp
@@ -576,6 +576,20 @@ public:
         return m_2d_screen_mode->value();
     }
 
+    // Chroma-key void is live: the void around the 2D screen clears to the user's key so runtimes
+    // like Virtual Desktop can composite camera passthrough in its place. OpenXR only -- the OpenVR
+    // 2D path has no void surface to color.
+    bool is_chroma_void_active() const {
+        return m_void_passthrough->value() && is_using_2d_screen() && get_runtime()->is_openxr();
+    }
+
+    // The configured chroma key, ungated. sRGB variant for UNORM-view surfaces (screen textures --
+    // also the space the runtime's chroma filter sees); linear for sRGB-view clears.
+    glm::vec4 get_void_key_color_srgb() const;
+    glm::vec4 get_void_key_color_linear() const;
+    // Void clear color for this frame: the key, or black while inactive/unfocused.
+    glm::vec4 get_screen_capture_clear_color() const;
+
     bool is_roomscale_enabled() const {
         return m_roomscale_movement->value() && !m_aim_temp_disabled;
     }
@@ -895,6 +909,9 @@ private:
     const ModToggle::Ptr m_decoupled_pitch_ui_adjust{ ModToggle::create(generate_name("DecoupledPitchUIAdjust"), true) };
     const ModToggle::Ptr m_load_blueprint_code{ ModToggle::create(generate_name("LoadBlueprintCode"), false, true) };
     const ModToggle::Ptr m_2d_screen_mode{ ModToggle::create(generate_name("2DScreenMode"), false) };
+    // Chroma-key void for runtime passthrough (e.g. Virtual Desktop). Color packed 0xRRGGBB.
+    const ModToggle::Ptr m_void_passthrough{ ModToggle::create(generate_name("PassthroughVoid"), false) };
+    const ModInt32::Ptr m_void_color{ ModInt32::create(generate_name("PassthroughVoidColor"), 0xFF00FF) };
     const ModToggle::Ptr m_roomscale_movement{ ModToggle::create(generate_name("RoomscaleMovement"), false) };
     const ModToggle::Ptr m_roomscale_sweep{ ModToggle::create(generate_name("RoomscaleMovementSweep"), true) };
     const ModToggle::Ptr m_swap_controllers{ ModToggle::create(generate_name("SwapControllerInputs"), false) };
@@ -1041,6 +1058,8 @@ public:
             *m_decoupled_pitch_ui_adjust,
             *m_load_blueprint_code,
             *m_2d_screen_mode,
+            *m_void_passthrough,
+            *m_void_color,
             *m_roomscale_movement,
             *m_roomscale_sweep,
             *m_swap_controllers,

--- a/src/mods/vr/ChromaVoid.hpp
+++ b/src/mods/vr/ChromaVoid.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+#include <windows.h>
+
+// Shared chroma-void geometry for the passthrough key feature. D3D11_RECT and D3D12_RECT are both
+// RECT-layout, so one set of helpers serves both backends and their math cannot drift.
+namespace vrmod::chroma {
+constexpr LONG PAD_PX = 4;
+// Black ring at the projection layer's outer edge so a cropped-FOV boundary blends black-on-black
+// instead of flashing the key during reprojection.
+constexpr LONG EDGE_GUARD_PX = 16;
+
+// Border pad clamped so tiny render targets can never produce inverted rects.
+// NB: (std::min) parenthesized -- windows.h min/max macros may be live in including TUs.
+inline LONG clamped_pad(LONG w, LONG h) {
+    const LONG limit = (std::min)(w / 4, h / 4);
+    return (std::max)(0L, (std::min)(PAD_PX, limit));
+}
+
+// The four edge strips of a w*h surface, `pad` px thick.
+inline std::array<RECT, 4> border_ring(LONG w, LONG h, LONG pad) {
+    return {{
+        {0, 0, w, pad},
+        {0, h - pad, w, h},
+        {0, pad, pad, h - pad},
+        {w - pad, pad, w, h - pad},
+    }};
+}
+
+// Interior key rect for one eye's void, inset `guard` px inside the SUBMITTED region (the
+// view_bounds crop of the texture), not the texture edge -- otherwise a projection-override crop
+// larger than the guard would discard the whole black ring. Guard is clamped against the region.
+inline RECT guard_interior(const float bounds[4], LONG eye_w, LONG h, LONG guard, LONG x_off) {
+    const LONG l = x_off + (LONG)(bounds[0] * (float)eye_w);
+    const LONG r = x_off + (LONG)(bounds[1] * (float)eye_w);
+    const LONG t = (LONG)(bounds[2] * (float)h);
+    const LONG b = (LONG)(bounds[3] * (float)h);
+    const LONG limit = (std::min)((r - l) / 4, (b - t) / 4);
+    const LONG g = (std::max)(0L, (std::min)(guard, limit));
+    return {l + g, t + g, r - g, b - g};
+}
+} // namespace vrmod::chroma

--- a/src/mods/vr/D3D11Component.cpp
+++ b/src/mods/vr/D3D11Component.cpp
@@ -17,6 +17,8 @@ namespace pixel_shader1 {
 #include "Framework.hpp"
 #include "../VR.hpp"
 
+#include "ChromaVoid.hpp"
+
 #include "D3D11Component.hpp"
 
 //#define VERBOSE_D3D11
@@ -391,6 +393,22 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
 
     const auto is_2d_screen = vr->is_using_2d_screen();
 
+    // Chroma-key void state, evaluated once per frame. When active, the void around the 2D screen
+    // clears to the key (for runtime passthrough), the screen texture gets a key-colored border,
+    // and the content is inset so the quad's screen-space edge blends key-on-key in the compositor
+    // (a game-colored edge would blend into un-keyable fringe).
+    const bool chroma_void = vr->is_chroma_void_active();
+    const auto void_color = vr->get_screen_capture_clear_color();
+
+    // Ring color must match the screen textures' view gamma (sRGB views under extreme compat).
+    float ring_clear[4]{0.0f, 0.0f, 0.0f, 1.0f};
+    if (chroma_void && !(void_color.x == 0.0f && void_color.y == 0.0f && void_color.z == 0.0f)) {
+        const auto key = m_2d_screen_srgb_views ? vr->get_void_key_color_linear() : vr->get_void_key_color_srgb();
+        ring_clear[0] = key.x;
+        ring_clear[1] = key.y;
+        ring_clear[2] = key.z;
+    }
+
     auto draw_2d_view = [&]() {
         if (!is_2d_screen || !m_engine_tex_ref.has_texture() || !m_engine_tex_ref.has_srv()) {
             return;
@@ -399,6 +417,10 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
         DX11StateBackup backup{context.Get()};
 
         float clear_color[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+        const auto rt_size = g_framework->get_d3d11_rt_size();
+        const LONG pad = chroma_void ? chroma::clamped_pad((LONG)rt_size.x, (LONG)rt_size.y) : 0;
+        const RECT content_dest{pad, pad, (LONG)rt_size.x - pad, (LONG)rt_size.y - pad};
 
         // Clear previous frame
         for (auto& screen : m_2d_screen_tex) {
@@ -410,14 +432,17 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
             m_game_batch.get(),
             m_engine_tex_ref,
             m_2d_screen_tex[0],
-            RECT{0, 0, (LONG)((float)m_backbuffer_size[0] / 2.0f), (LONG)m_backbuffer_size[1]}
+            RECT{0, 0, (LONG)((float)m_backbuffer_size[0] / 2.0f), (LONG)m_backbuffer_size[1]},
+            content_dest
         );
 
         if (m_engine_ui_ref.has_texture() && m_engine_ui_ref.has_srv()) {
             render_srv_to_rtv(
                 m_game_batch.get(),
                 m_engine_ui_ref,
-                m_2d_screen_tex[0]
+                m_2d_screen_tex[0],
+                std::nullopt,
+                content_dest
             );
         }
 
@@ -427,14 +452,17 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
                 render_srv_to_rtv(
                     m_game_batch.get(),
                     m_scene_capture_tex_ref,
-                    m_2d_screen_tex[1]
+                    m_2d_screen_tex[1],
+                    std::nullopt,
+                    content_dest
                 );
             } else {
                 render_srv_to_rtv(
                     m_game_batch.get(),
                     m_engine_tex_ref,
                     m_2d_screen_tex[1],
-                    RECT{(LONG)((float)m_backbuffer_size[0] / 2.0f), 0, (LONG)((float)m_backbuffer_size[0]), (LONG)m_backbuffer_size[1]}
+                    RECT{(LONG)((float)m_backbuffer_size[0] / 2.0f), 0, (LONG)((float)m_backbuffer_size[0]), (LONG)m_backbuffer_size[1]},
+                    content_dest
                 );
             }
 
@@ -442,8 +470,21 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
                 render_srv_to_rtv(
                     m_game_batch.get(),
                     m_engine_ui_ref,
-                    m_2d_screen_tex[1]
+                    m_2d_screen_tex[1],
+                    std::nullopt,
+                    content_dest
                 );
+            }
+        }
+
+        // Border ring in the key color (rect clears bypass blending, keeping the ring pure).
+        if (chroma_void && pad > 0 && m_context1 != nullptr) {
+            const auto ring = chroma::border_ring((LONG)rt_size.x, (LONG)rt_size.y, pad);
+
+            for (auto& screen : m_2d_screen_tex) {
+                if (screen.rtv != nullptr) {
+                    m_context1->ClearView(screen.rtv.Get(), ring_clear, ring.data(), (UINT)ring.size());
+                }
             }
         }
 
@@ -533,29 +574,32 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
 
         if (runtime->is_openxr() && runtime->ready()) {
             LOG_VERBOSE("Copying left eye");
-            //m_openxr.copy(0, backbuffer.Get());
-            D3D11_BOX src_box{};
-            src_box.left = 0;
-            src_box.top = 0;
-            src_box.bottom = m_backbuffer_size[1];
-            src_box.front = 0;
-            src_box.back = 1;
 
-            if (vr->is_extreme_compatibility_mode_enabled()) {
-                src_box.right = m_backbuffer_size[0];
+            if (is_2d_screen) {
+                // 2D: the projection layer is void by design (content rides the quads) -- clear
+                // instead of copying the blacked backbuffer, and skip depth (nothing to reproject).
+                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, nullptr, nullptr,
+                    [&](ID3D11Texture2D* rt) { clear_void_tex(context.Get(), rt, void_color, 0); });
             } else {
-                src_box.right = m_backbuffer_size[0] / 2;
+                D3D11_BOX src_box{};
+                src_box.left = 0;
+                src_box.top = 0;
+                src_box.bottom = m_backbuffer_size[1];
+                src_box.front = 0;
+                src_box.back = 1;
+
+                if (vr->is_extreme_compatibility_mode_enabled()) {
+                    src_box.right = m_backbuffer_size[0];
+                } else {
+                    src_box.right = m_backbuffer_size[0] / 2;
+                }
+
+                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), &src_box);
             }
 
-            m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), &src_box);
-
-            if (scene_depth_tex != nullptr) {
+            if (scene_depth_tex != nullptr && !is_2d_screen) {
                 m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_LEFT_EYE, scene_depth_tex.Get(), nullptr);
             }
-
-            /*if (scene_depth_tex != nullptr) {
-                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DEPTH_LEFT, scene_depth_tex.Get(), &src_box);
-            }*/
         }
 
         if (runtime->is_openvr()) {
@@ -603,24 +647,39 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
         }};
 
         if (runtime->ready() && runtime->is_openxr()) {
+            // 2D: the projection layer is void by design -- clear the swapchains instead of copying,
+            // and skip depth (nothing to reproject).
+            const auto clear_swapchain = [&](runtimes::OpenXR::SwapchainIndex idx) {
+                const int eye = idx == runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE ? -1
+                    : (idx == runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE ? 1 : 0);
+                m_openxr.copy((uint32_t)idx, nullptr, nullptr, [&](ID3D11Texture2D* rt) {
+                    clear_void_tex(context.Get(), rt, void_color, eye);
+                });
+            };
+
             if (is_actually_afr && !is_afr && !m_submitted_left_eye) {
                 LOG_VERBOSE("Copying left eye");
-                D3D11_BOX src_box{};
-                src_box.left = 0;
-                src_box.top = 0;
-                src_box.bottom = m_backbuffer_size[1];
-                src_box.front = 0;
-                src_box.back = 1;
 
-                if (vr->is_extreme_compatibility_mode_enabled()) {
-                    src_box.right = m_backbuffer_size[0];
+                if (is_2d_screen) {
+                    clear_swapchain(runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE);
                 } else {
-                    src_box.right = m_backbuffer_size[0] / 2;
+                    D3D11_BOX src_box{};
+                    src_box.left = 0;
+                    src_box.top = 0;
+                    src_box.bottom = m_backbuffer_size[1];
+                    src_box.front = 0;
+                    src_box.back = 1;
+
+                    if (vr->is_extreme_compatibility_mode_enabled()) {
+                        src_box.right = m_backbuffer_size[0];
+                    } else {
+                        src_box.right = m_backbuffer_size[0] / 2;
+                    }
+
+                    m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), &src_box);
                 }
 
-                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), &src_box);
-
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_LEFT_EYE, scene_depth_tex.Get(), nullptr);
                 }
             }
@@ -628,40 +687,46 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
             LOG_VERBOSE("Copying right eye");
 
             if (is_actually_afr) {
-                D3D11_BOX src_box{};
-                if (!vr->is_extreme_compatibility_mode_enabled()) {
-                    if (!is_afr) {
-                        src_box.left = m_backbuffer_size[0] / 2;
+                if (is_2d_screen) {
+                    clear_swapchain(runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE);
+                } else {
+                    D3D11_BOX src_box{};
+                    if (!vr->is_extreme_compatibility_mode_enabled()) {
+                        if (!is_afr) {
+                            src_box.left = m_backbuffer_size[0] / 2;
+                            src_box.right = m_backbuffer_size[0];
+                            src_box.top = 0;
+                            src_box.bottom = m_backbuffer_size[1];
+                            src_box.front = 0;
+                            src_box.back = 1;
+                        } else { // Copy the left eye on AFR
+                            src_box.left = 0;
+                            src_box.right = m_backbuffer_size[0] / 2;
+                            src_box.top = 0;
+                            src_box.bottom = m_backbuffer_size[1];
+                            src_box.front = 0;
+                            src_box.back = 1;
+                        }
+                    } else {
+                        src_box.left = 0;
                         src_box.right = m_backbuffer_size[0];
                         src_box.top = 0;
                         src_box.bottom = m_backbuffer_size[1];
                         src_box.front = 0;
                         src_box.back = 1;
-                    } else { // Copy the left eye on AFR
-                        src_box.left = 0;
-                        src_box.right = m_backbuffer_size[0] / 2;
-                        src_box.top = 0;
-                        src_box.bottom = m_backbuffer_size[1];
-                        src_box.front = 0;
-                        src_box.back = 1;
-                    }   
-                } else {
-                    src_box.left = 0;
-                    src_box.right = m_backbuffer_size[0];
-                    src_box.top = 0;
-                    src_box.bottom = m_backbuffer_size[1];
-                    src_box.front = 0;
-                    src_box.back = 1;
+                    }
+
+                    m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE, backbuffer.Get(), &src_box);
                 }
 
-                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE, backbuffer.Get(), &src_box);
-
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_RIGHT_EYE, scene_depth_tex.Get(), nullptr);
                 }
             } else {
                 // Copy over the entire double wide back buffer instead
-                if (!m_scene_capture_tex_ref.has_texture()) {
+                if (is_2d_screen) {
+                    clear_swapchain(runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE);
+                } else if (!m_scene_capture_tex_ref.has_texture()) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE, backbuffer.Get(), nullptr);
                 } else {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE, nullptr, nullptr, [&](ID3D11Texture2D* render_target) {
@@ -679,7 +744,7 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
                     });
                 }
 
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DEPTH, scene_depth_tex.Get(), nullptr);
                 }
             }
@@ -716,7 +781,7 @@ vr::EVRCompositorError D3D11Component::on_frame(VR* vr) {
                 }
             }
             
-            auto result = vr->m_openxr->end_frame(quad_layers, scene_depth_tex != nullptr);
+            auto result = vr->m_openxr->end_frame(quad_layers, scene_depth_tex != nullptr && !is_2d_screen);
 
             vr->m_openxr->needs_pose_update = true;
             vr->m_submitted = result == XR_SUCCESS;
@@ -1014,6 +1079,7 @@ void D3D11Component::on_reset(VR* vr) {
     m_left_eye_srv.Reset();
     m_right_eye_srv.Reset();
     m_ui_tex.Reset();
+    m_context1.Reset();
     m_vs_shader_blob.Reset();
     m_ps_shader_blob.Reset();
     m_vs_shader.Reset();
@@ -1212,6 +1278,87 @@ void D3D11Component::render_srv_to_rtv(DirectX::DX11::SpriteBatch* batch, Textur
     batch->End();
 }
 
+void D3D11Component::render_srv_to_rtv(DirectX::DX11::SpriteBatch* batch, TextureContext& srv, TextureContext& rtv, std::optional<RECT> src_rect, const RECT& dest_rect) {
+    D3D11_TEXTURE2D_DESC dest_desc{};
+    ((ID3D11Texture2D*)rtv.tex.Get())->GetDesc(&dest_desc);
+
+    auto& hook = g_framework->get_d3d11_hook();
+    auto device = hook->get_device();
+
+    ComPtr<ID3D11DeviceContext> context{};
+    device->GetImmediateContext(&context);
+
+    ID3D11RenderTargetView* views[] = { rtv };
+    context->OMSetRenderTargets(1, views, nullptr);
+
+    batch->Begin();
+
+    D3D11_VIEWPORT viewport{};
+    viewport.Width = dest_desc.Width;
+    viewport.Height = dest_desc.Height;
+    batch->SetViewport(viewport);
+
+    context->RSSetViewports(1, &viewport);
+
+    D3D11_RECT scissor_rect{};
+    scissor_rect.left = 0;
+    scissor_rect.top = 0;
+    scissor_rect.right = dest_desc.Width;
+    scissor_rect.bottom = dest_desc.Height;
+    context->RSSetScissorRects(1, &scissor_rect);
+
+    if (src_rect) {
+        batch->Draw(srv, dest_rect, &*src_rect, DirectX::Colors::White);
+    } else {
+        batch->Draw(srv, dest_rect, DirectX::Colors::White);
+    }
+
+    batch->End();
+}
+
+bool D3D11Component::clear_void_tex(ID3D11DeviceContext* context, ID3D11Resource* tex, const glm::vec4& void_color, int eye) {
+    auto& vr = VR::get();
+    float void_clear[4]{void_color.x, void_color.y, void_color.z, void_color.w};
+
+    const TextureContext ctx{tex, std::nullopt};
+    auto* rtv = ctx.rtv.Get();
+
+    if (rtv == nullptr) {
+        return false;
+    }
+
+    const bool is_black = void_color.x == 0.0f && void_color.y == 0.0f && void_color.z == 0.0f;
+
+    if (is_black || m_context1 == nullptr) {
+        context->ClearRenderTargetView(rtv, void_clear);
+        return true;
+    }
+
+    // Black base + inset key interior: the layer's outer edge then blends black-on-black at a
+    // cropped-FOV boundary instead of flashing the key during reprojection. The interior is placed
+    // inside the submitted view-bounds region, not the texture edge.
+    const float black[4]{0.0f, 0.0f, 0.0f, 1.0f};
+    context->ClearRenderTargetView(rtv, black);
+
+    D3D11_TEXTURE2D_DESC desc{};
+    ((ID3D11Texture2D*)tex)->GetDesc(&desc);
+
+    const auto& bounds = vr->get_runtime()->view_bounds;
+
+    if (eye < 0) {
+        const auto eye_w = (LONG)desc.Width / 2;
+        const D3D11_RECT rects[2]{
+            chroma::guard_interior(bounds[0], eye_w, (LONG)desc.Height, chroma::EDGE_GUARD_PX, 0),
+            chroma::guard_interior(bounds[1], eye_w, (LONG)desc.Height, chroma::EDGE_GUARD_PX, eye_w)};
+        m_context1->ClearView(rtv, void_clear, rects, 2);
+    } else {
+        const auto rect = chroma::guard_interior(bounds[eye], (LONG)desc.Width, (LONG)desc.Height, chroma::EDGE_GUARD_PX, 0);
+        m_context1->ClearView(rtv, void_clear, &rect, 1);
+    }
+
+    return true;
+}
+
 bool D3D11Component::setup() {
     SPDLOG_INFO_EVERY_N_SEC(1, "[VR] Setting up D3D11 textures...");
 
@@ -1226,6 +1373,9 @@ bool D3D11Component::setup() {
     ComPtr<ID3D11DeviceContext> context{};
 
     device->GetImmediateContext(&context);
+
+    context.As(&m_context1); // 11.1 rect clears; null on ancient runtimes (edge guard degrades gracefully)
+    m_2d_screen_srgb_views = vr->is_extreme_compatibility_mode_enabled();
 
     // Get back buffer.
     ComPtr<ID3D11Texture2D> real_backbuffer{};

--- a/src/mods/vr/D3D11Component.hpp
+++ b/src/mods/vr/D3D11Component.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <d3d11.h>
+#include <d3d11_1.h>
 #include <dxgi.h>
 #include <openvr.h>
 #include <wrl.h>
@@ -59,6 +60,17 @@ private:
         TextureContext& srv,
         TextureContext& rtv,
         const RECT& src_rect);
+
+    void render_srv_to_rtv(
+        DirectX::DX11::SpriteBatch* batch,
+        TextureContext& srv,
+        TextureContext& rtv,
+        std::optional<RECT> src_rect,
+        const RECT& dest_rect);
+
+    // Void clear with edge guard: black base + inset key interior, placed inside the submitted
+    // view-bounds region. eye = 0/1, or -1 for a double-wide target (both eyes).
+    bool clear_void_tex(ID3D11DeviceContext* context, ID3D11Resource* tex, const glm::vec4& void_color, int eye);
 
     struct ShaderGlobals {
         DirectX::XMMATRIX mvp{};
@@ -155,6 +167,11 @@ private:
 
     std::unique_ptr<DirectX::DX11::SpriteBatch> m_backbuffer_batch{};
     std::unique_ptr<DirectX::DX11::SpriteBatch> m_game_batch{};
+
+    // Cached 11.1 interface for rect clears (immutable for the device's lifetime).
+    ComPtr<ID3D11DeviceContext1> m_context1{};
+    // Extreme compat leaves the 2D screen views sRGB; ring colors must match the view gamma.
+    bool m_2d_screen_srgb_views{false};
 
     vr::HmdMatrix44_t m_left_eye_proj{};
     vr::HmdMatrix44_t m_right_eye_proj{};

--- a/src/mods/vr/D3D12Component.cpp
+++ b/src/mods/vr/D3D12Component.cpp
@@ -16,6 +16,7 @@
 
 #include "d3d12/DirectXTK.hpp"
 
+#include "ChromaVoid.hpp"
 #include "D3D12Component.hpp"
 
 //#define AFR_DEPTH_TEMP_DISABLED
@@ -270,6 +271,21 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
     const float clear_color[] = { 0.0f, 0.0f, 0.0f, 0.0f };
     const auto is_2d_screen = vr->is_using_2d_screen();
 
+    // Chroma-key void state, evaluated once per frame. When active, the void around the 2D screen
+    // clears to the key (for runtime passthrough), the screen texture gets a key-colored border,
+    // and the content is inset so the quad's screen-space edge blends key-on-key in the compositor.
+    const bool chroma_void = vr->is_chroma_void_active();
+    const auto void_color = vr->get_screen_capture_clear_color();
+
+    // The screen textures have UNORM views, so their ring takes the raw sRGB key (black while gated).
+    float ring_clear[4]{0.0f, 0.0f, 0.0f, 1.0f};
+    if (chroma_void && !(void_color.x == 0.0f && void_color.y == 0.0f && void_color.z == 0.0f)) {
+        const auto key = vr->get_void_key_color_srgb();
+        ring_clear[0] = key.x;
+        ring_clear[1] = key.y;
+        ring_clear[2] = key.z;
+    }
+
     auto draw_2d_view = [&](d3d12::CommandContext& commands, ID3D12Resource* render_target) {
         if (ui_should_invert_alpha && m_game_ui_tex.texture.Get() != nullptr && m_game_ui_tex.srv_heap != nullptr) {
             d3d12::render_srv_to_rtv(m_ui_batch_alpha_invert.get(), commands.cmd_list.Get(), m_game_ui_tex, m_game_ui_tex, std::nullopt, ENGINE_SRC_COLOR, ENGINE_SRC_COLOR);
@@ -278,6 +294,10 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
         draw_spectator_view(commands.cmd_list.Get(), is_right_eye_frame);
 
         if (is_2d_screen && m_game_tex.texture.Get() != nullptr && m_game_tex.srv_heap != nullptr) {
+            const auto rt_size = g_framework->get_d3d12_rt_size();
+            const LONG pad = chroma_void ? chroma::clamped_pad((LONG)rt_size.x, (LONG)rt_size.y) : 0;
+            const RECT content_dest{pad, pad, (LONG)rt_size.x - pad, (LONG)rt_size.y - pad};
+
             // Clear previous frame
             for (auto& screen : m_2d_screen_tex) {
                 commands.clear_rtv(screen, clear_color, ENGINE_SRC_COLOR);
@@ -290,6 +310,7 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                 m_game_tex,
                 m_2d_screen_tex[0],
                 RECT{0, 0, (LONG)((float)m_backbuffer_size[0] / 2.0f), (LONG)m_backbuffer_size[1]},
+                content_dest,
                 ENGINE_SRC_COLOR,
                 ENGINE_SRC_COLOR
             );
@@ -300,6 +321,8 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                     commands.cmd_list.Get(),
                     m_game_ui_tex,
                     m_2d_screen_tex[0],
+                    std::nullopt,
+                    content_dest,
                     ENGINE_SRC_COLOR,
                     ENGINE_SRC_COLOR
                 );
@@ -313,6 +336,8 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                         commands.cmd_list.Get(),
                         m_scene_capture_tex,
                         m_2d_screen_tex[1],
+                        std::nullopt,
+                        content_dest,
                         ENGINE_SRC_COLOR,
                         ENGINE_SRC_COLOR
                     );
@@ -323,6 +348,7 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                         m_game_tex,
                         m_2d_screen_tex[1],
                         RECT{(LONG)((float)m_backbuffer_size[0] / 2.0f), 0, (LONG)((float)m_backbuffer_size[0]), (LONG)m_backbuffer_size[1]},
+                        content_dest,
                         ENGINE_SRC_COLOR,
                         ENGINE_SRC_COLOR
                     );
@@ -334,9 +360,20 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                         commands.cmd_list.Get(),
                         m_game_ui_tex,
                         m_2d_screen_tex[1],
+                        std::nullopt,
+                        content_dest,
                         ENGINE_SRC_COLOR,
                         ENGINE_SRC_COLOR
                     );
+                }
+            }
+
+            // Border ring in the key color (rect clears bypass blending, keeping the ring pure).
+            if (chroma_void && pad > 0) {
+                const auto ring = chroma::border_ring((LONG)rt_size.x, (LONG)rt_size.y, pad);
+
+                for (auto& screen : m_2d_screen_tex) {
+                    commands.clear_rtv(screen, ring_clear, ring.data(), (uint32_t)ring.size(), ENGINE_SRC_COLOR);
                 }
             }
 
@@ -440,22 +477,28 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
 
         // OpenXR texture
         if (runtime->is_openxr() && vr->m_openxr->ready()) {
-            D3D12_BOX src_box{};
-            src_box.left = 0;
-            src_box.top = 0;
-            src_box.bottom = m_backbuffer_size[1];
-            src_box.front = 0;
-            src_box.back = 1;
-
-            if (vr->is_extreme_compatibility_mode_enabled()) {
-                src_box.right = m_backbuffer_size[0];
+            if (is_2d_screen) {
+                // 2D: the projection layer is void by design (content rides the quads) -- clear
+                // instead of copying the blacked backbuffer, and skip depth (nothing to reproject).
+                m_openxr.clear((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, void_color, 0);
             } else {
-                src_box.right = m_backbuffer_size[0] / 2;
+                D3D12_BOX src_box{};
+                src_box.left = 0;
+                src_box.top = 0;
+                src_box.bottom = m_backbuffer_size[1];
+                src_box.front = 0;
+                src_box.back = 1;
+
+                if (vr->is_extreme_compatibility_mode_enabled()) {
+                    src_box.right = m_backbuffer_size[0];
+                } else {
+                    src_box.right = m_backbuffer_size[0] / 2;
+                }
+
+                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
             }
 
-            m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
-
-            if (scene_depth_tex != nullptr) {
+            if (scene_depth_tex != nullptr && !is_2d_screen) {
                 m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_LEFT_EYE, scene_depth_tex.Get(), ENGINE_SRC_DEPTH, nullptr);
             }
         }
@@ -494,69 +537,81 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
 
         // OpenXR texture
         if (runtime->is_openxr() && vr->m_openxr->ready()) {
+            // 2D: the projection layer is void by design -- clear the swapchains instead of copying,
+            // and skip depth (nothing to reproject).
             if (is_actually_afr && !is_afr && !m_submitted_left_eye) {
-                D3D12_BOX src_box{};
-                src_box.left = 0;
-                src_box.top = 0;
-                src_box.bottom = m_backbuffer_size[1];
-                src_box.front = 0;
-                src_box.back = 1;
-
-                if (vr->is_extreme_compatibility_mode_enabled()) {
-                    src_box.right = m_backbuffer_size[0];
+                if (is_2d_screen) {
+                    m_openxr.clear((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, void_color, 0);
                 } else {
-                    src_box.right = m_backbuffer_size[0] / 2;
+                    D3D12_BOX src_box{};
+                    src_box.left = 0;
+                    src_box.top = 0;
+                    src_box.bottom = m_backbuffer_size[1];
+                    src_box.front = 0;
+                    src_box.back = 1;
+
+                    if (vr->is_extreme_compatibility_mode_enabled()) {
+                        src_box.right = m_backbuffer_size[0];
+                    } else {
+                        src_box.right = m_backbuffer_size[0] / 2;
+                    }
+
+                    m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
                 }
 
-                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_LEFT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
-
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_LEFT_EYE, scene_depth_tex.Get(), ENGINE_SRC_DEPTH, nullptr);
                 }
             }
 
             if (is_actually_afr) {
-                D3D12_BOX src_box{};
+                if (is_2d_screen) {
+                    m_openxr.clear((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE, void_color, 1);
+                } else {
+                    D3D12_BOX src_box{};
 
-                if (!vr->is_extreme_compatibility_mode_enabled()) {
-                    if (!is_afr) {
-                        src_box.left = m_backbuffer_size[0] / 2;
+                    if (!vr->is_extreme_compatibility_mode_enabled()) {
+                        if (!is_afr) {
+                            src_box.left = m_backbuffer_size[0] / 2;
+                            src_box.right = m_backbuffer_size[0];
+                            src_box.top = 0;
+                            src_box.bottom = m_backbuffer_size[1];
+                            src_box.front = 0;
+                            src_box.back = 1;
+                        } else { // Copy the left eye on AFR
+                            src_box.left = 0;
+                            src_box.right = m_backbuffer_size[0] / 2;
+                            src_box.top = 0;
+                            src_box.bottom = m_backbuffer_size[1];
+                            src_box.front = 0;
+                            src_box.back = 1;
+                        }
+                    } else {
+                        src_box.left = 0;
                         src_box.right = m_backbuffer_size[0];
                         src_box.top = 0;
                         src_box.bottom = m_backbuffer_size[1];
                         src_box.front = 0;
                         src_box.back = 1;
-                    } else { // Copy the left eye on AFR
-                        src_box.left = 0;
-                        src_box.right = m_backbuffer_size[0] / 2;
-                        src_box.top = 0;
-                        src_box.bottom = m_backbuffer_size[1];
-                        src_box.front = 0;
-                        src_box.back = 1;
-                    }   
-                } else {
-                    src_box.left = 0;
-                    src_box.right = m_backbuffer_size[0];
-                    src_box.top = 0;
-                    src_box.bottom = m_backbuffer_size[1];
-                    src_box.front = 0;
-                    src_box.back = 1;
+                    }
+
+                    m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
                 }
 
-                m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_RIGHT_EYE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, &src_box);
-
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::AFR_DEPTH_RIGHT_EYE, scene_depth_tex.Get(), ENGINE_SRC_DEPTH, nullptr);
                 }
             } else {
                 // Copy over the entire double wide instead
-                if (m_scene_capture_tex.texture.Get() == nullptr) {
+                if (is_2d_screen) {
+                    m_openxr.clear((uint32_t)runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE, void_color, -1);
+                } else if (m_scene_capture_tex.texture.Get() == nullptr) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE, backbuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr);
                 } else {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DOUBLE_WIDE, nullptr, pre_render, std::nullopt, D3D12_RESOURCE_STATE_RENDER_TARGET, nullptr);
                 }
 
-                if (scene_depth_tex != nullptr) {
+                if (scene_depth_tex != nullptr && !is_2d_screen) {
                     m_openxr.copy((uint32_t)runtimes::OpenXR::SwapchainIndex::DEPTH, scene_depth_tex.Get(), ENGINE_SRC_DEPTH, nullptr);
                 }
             }
@@ -674,7 +729,7 @@ vr::EVRCompositorError D3D12Component::on_frame(VR* vr) {
                 }
             }
 
-            auto result = vr->m_openxr->end_frame(quad_layers, scene_depth_tex.Get() != nullptr);
+            auto result = vr->m_openxr->end_frame(quad_layers, scene_depth_tex.Get() != nullptr && !is_2d_screen);
 
             if (result == XR_ERROR_LAYER_INVALID) {
                 spdlog::info("[VR] Attempting to correct invalid layer");
@@ -1172,7 +1227,10 @@ bool D3D12Component::setup() {
     heap_props.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
     heap_props.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
 
-    if (vr->is_using_2d_screen()) {
+    // 2D mode composites into these textures and rides them on the quad layers; the mode can toggle
+    // at runtime without a texture rebuild (nothing forces setup() on toggle), so allocate
+    // unconditionally -- matching D3D11.
+    {
         auto screen_desc = backbuffer_desc;
         screen_desc.Flags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
         screen_desc.Flags &= ~D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
@@ -1386,6 +1444,7 @@ std::optional<std::string> D3D12Component::OpenXR::create_swapchains() {
 
         auto& ctx = this->contexts[i];
 
+        ctx.rtv_format = (DXGI_FORMAT)swapchain_create_info.format;
         ctx.textures.clear();
         ctx.textures.resize(image_count);
         ctx.texture_contexts.clear();
@@ -1813,5 +1872,106 @@ void D3D12Component::OpenXR::copy(
             ctx.ever_acquired = true;
         }
     }
+}
+
+void D3D12Component::OpenXR::clear(uint32_t swapchain_idx, const glm::vec4& void_color, int eye) {
+    std::scoped_lock _{this->mtx};
+
+    auto vr = VR::get();
+
+    if (vr->m_openxr->frame_state.shouldRender != XR_TRUE) {
+        return;
+    }
+
+    if (!vr->m_openxr->frame_began) {
+        if (vr->get_synchronize_stage() != VR::SynchronizeStage::VERY_LATE) {
+            spdlog::error("[VR] OpenXR: Frame not begun when trying to clear.");
+            return;
+        }
+    }
+
+    if (!this->contexts.contains(swapchain_idx) || !vr->m_openxr->swapchains.contains(swapchain_idx)) {
+        spdlog::error("[VR] OpenXR: Trying to clear swapchain {} but it doesn't exist.", swapchain_idx);
+        return;
+    }
+
+    const auto& swapchain = vr->m_openxr->swapchains[swapchain_idx];
+    auto& ctx = this->contexts[swapchain_idx];
+
+    XrSwapchainImageAcquireInfo acquire_info{XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO};
+
+    uint32_t texture_index{};
+    auto result = xrAcquireSwapchainImage(swapchain.handle, &acquire_info, &texture_index);
+
+    if (result != XR_SUCCESS) {
+        spdlog::error("[VR] xrAcquireSwapchainImage failed: {}", vr->m_openxr->get_result_string(result));
+        return;
+    }
+
+    ctx.num_textures_acquired++;
+
+    XrSwapchainImageWaitInfo wait_info{XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO};
+    wait_info.timeout = XR_INFINITE_DURATION;
+    result = xrWaitSwapchainImage(swapchain.handle, &wait_info);
+
+    if (result == XR_SUCCESS) {
+        auto& texture_ctx = ctx.texture_contexts[texture_index];
+        texture_ctx->commands.wait(INFINITE);
+
+        // Lazily bind an RTV to this image; kept until the swapchains are destroyed. View with the
+        // REQUESTED swapchain format, never GetDesc() -- the runtime's images may be typeless, and a
+        // typeless RTV faults the device.
+        if (texture_ctx->texture.Get() != ctx.textures[texture_index].texture || texture_ctx->rtv_heap == nullptr) {
+            texture_ctx->texture = ctx.textures[texture_index].texture;
+
+            auto device = g_framework->get_d3d12_hook()->get_device();
+            const auto view_format = ctx.rtv_format != DXGI_FORMAT_UNKNOWN ? std::optional<DXGI_FORMAT>{ctx.rtv_format} : std::nullopt;
+            if (!texture_ctx->create_rtv(device, view_format)) {
+                spdlog::error("[VR] Failed to create RTV for swapchain {} clear.", swapchain_idx);
+            }
+        }
+
+        const float key_color[4]{void_color.x, void_color.y, void_color.z, void_color.w};
+        const bool is_black = void_color.x == 0.0f && void_color.y == 0.0f && void_color.z == 0.0f;
+
+        if (is_black) {
+            texture_ctx->commands.clear_rtv(*texture_ctx, key_color, D3D12_RESOURCE_STATE_RENDER_TARGET);
+        } else {
+            // Black base + inset key interior: the layer's outer edge then blends black-on-black at
+            // a cropped-FOV boundary instead of flashing the key during reprojection. The interior
+            // sits inside the submitted view-bounds region, not the texture edge.
+            const float black[4]{0.0f, 0.0f, 0.0f, 1.0f};
+            texture_ctx->commands.clear_rtv(*texture_ctx, black, D3D12_RESOURCE_STATE_RENDER_TARGET);
+
+            const auto desc = texture_ctx->texture->GetDesc();
+            const auto& bounds = vr->m_openxr->view_bounds;
+
+            if (eye < 0) {
+                const auto eye_w = (LONG)desc.Width / 2;
+                const D3D12_RECT rects[2]{
+                    chroma::guard_interior(bounds[0], eye_w, (LONG)desc.Height, chroma::EDGE_GUARD_PX, 0),
+                    chroma::guard_interior(bounds[1], eye_w, (LONG)desc.Height, chroma::EDGE_GUARD_PX, eye_w)};
+                texture_ctx->commands.clear_rtv(*texture_ctx, key_color, rects, 2, D3D12_RESOURCE_STATE_RENDER_TARGET);
+            } else {
+                const auto rect = chroma::guard_interior(bounds[eye], (LONG)desc.Width, (LONG)desc.Height, chroma::EDGE_GUARD_PX, 0);
+                texture_ctx->commands.clear_rtv(*texture_ctx, key_color, &rect, 1, D3D12_RESOURCE_STATE_RENDER_TARGET);
+            }
+        }
+
+        texture_ctx->commands.execute();
+    } else {
+        spdlog::error("[VR] xrWaitSwapchainImage failed: {}", vr->m_openxr->get_result_string(result));
+    }
+
+    XrSwapchainImageReleaseInfo release_info{XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
+    result = xrReleaseSwapchainImage(swapchain.handle, &release_info);
+
+    if (result != XR_SUCCESS) {
+        spdlog::error("[VR] xrReleaseSwapchainImage failed: {}", vr->m_openxr->get_result_string(result));
+        return;
+    }
+
+    ctx.num_textures_acquired--;
+    ctx.ever_acquired = true;
 }
 } // namespace vrmod

--- a/src/mods/vr/D3D12Component.hpp
+++ b/src/mods/vr/D3D12Component.hpp
@@ -175,6 +175,11 @@ private:
         {
             this->copy(swapchain_idx, src, std::nullopt, std::nullopt, src_state, src_box);
         }
+
+        // Acquire + clear to the void color + release, without a source copy (2D projection layers).
+        // A non-black void gets a black edge-guard ring inside the submitted view-bounds region.
+        // eye = 0/1, or -1 for the double-wide (both eye halves).
+        void clear(uint32_t swapchain_idx, const glm::vec4& void_color, int eye);
         void wait_for_all_copies() {
             std::scoped_lock _{this->mtx};
 
@@ -204,6 +209,8 @@ private:
             uint32_t num_textures_acquired{0};
             uint32_t last_acquired_texture{0};
             bool ever_acquired{false};
+            // Requested (view) format for RTVs -- the runtime's images may be typeless.
+            DXGI_FORMAT rtv_format{DXGI_FORMAT_UNKNOWN};
         };
 
         std::unordered_map<uint32_t, SwapchainContext> contexts{};

--- a/src/mods/vr/OverlayComponent.cpp
+++ b/src/mods/vr/OverlayComponent.cpp
@@ -5,6 +5,7 @@
 #include "../VR.hpp"
 #include "../utility/ImGui.hpp"
 
+#include "ChromaVoid.hpp"
 #include "OverlayComponent.hpp"
 
 namespace vrmod {
@@ -829,7 +830,10 @@ std::optional<std::reference_wrapper<XrCompositionLayerQuad>> OverlayComponent::
     layer.type = XR_TYPE_COMPOSITION_LAYER_QUAD;
     const auto& ui_swapchain = vr->m_openxr->swapchains[(uint32_t)swapchain];
     layer.subImage.swapchain = ui_swapchain.handle;
-    layer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+    // 2D screen mode: the quad is a solid virtual screen carrying the composited world (+UI); the
+    // scene's backbuffer alpha is meaningless (often 0 -> an alpha-blended quad shows the scene as
+    // black, e.g. UE5.5+ titles), so submit opaque. The normal-VR UI slate stays source-alpha.
+    layer.layerFlags = vr->is_using_2d_screen() ? 0 : XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
     layer.subImage.imageRect.offset.x = 0;
     layer.subImage.imageRect.offset.y = 0;
     layer.subImage.imageRect.extent.width = ui_swapchain.width;
@@ -899,8 +903,14 @@ std::optional<std::reference_wrapper<XrCompositionLayerQuad>> OverlayComponent::
                 m_parent->m_intersect_state.intersecting = true;
 
                 if (auto it = vr->m_openxr->swapchains.find((uint32_t)runtimes::OpenXR::SwapchainIndex::UI); it != vr->m_openxr->swapchains.end()) {
-                    const auto client_x = (int32_t)((float)it->second.width * x);
-                    const auto client_y = (int32_t)((float)it->second.height * y);
+                    const auto w = (float)it->second.width;
+                    const auto h = (float)it->second.height;
+
+                    // Chroma padding insets the game content; map into the inset region so the
+                    // cursor lands on game pixels, not the key border.
+                    const auto pad = vr->is_chroma_void_active() ? (float)chroma::clamped_pad((LONG)w, (LONG)h) : 0.0f;
+                    const auto client_x = (int32_t)(pad + (w - 2.0f * pad) * x);
+                    const auto client_y = (int32_t)(pad + (h - 2.0f * pad) * y);
 
                     m_parent->m_intersect_state.swapchain_intersection_point = {client_x, client_y};
                 }
@@ -936,7 +946,8 @@ std::optional<std::reference_wrapper<XrCompositionLayerCylinderKHR>> OverlayComp
     layer.type = XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR;
     const auto& ui_swapchain = vr->m_openxr->swapchains[(uint32_t)swapchain];
     layer.subImage.swapchain = ui_swapchain.handle;
-    layer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+    // Carries the composited world in 2D mode -- same opaque rule as the quad.
+    layer.layerFlags = vr->is_using_2d_screen() ? 0 : XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
     layer.subImage.imageRect.offset.x = 0;
     layer.subImage.imageRect.offset.y = 0;
     layer.subImage.imageRect.extent.width = ui_swapchain.width;

--- a/src/mods/vr/d3d12/CommandContext.cpp
+++ b/src/mods/vr/d3d12/CommandContext.cpp
@@ -287,7 +287,7 @@ void CommandContext::copy_region_stereo(ID3D12Resource* srcleft, ID3D12Resource*
     this->has_commands = true;
 }
 
-void CommandContext::clear_rtv(ID3D12Resource* dst, D3D12_CPU_DESCRIPTOR_HANDLE rtv, const float* color, D3D12_RESOURCE_STATES dst_state) {
+void CommandContext::clear_rtv(ID3D12Resource* dst, D3D12_CPU_DESCRIPTOR_HANDLE rtv, const float* color, D3D12_RESOURCE_STATES dst_state, const D3D12_RECT* rects, uint32_t num_rects) {
     std::scoped_lock _{this->mtx};
 
     if (dst == nullptr) {
@@ -311,7 +311,7 @@ void CommandContext::clear_rtv(ID3D12Resource* dst, D3D12_CPU_DESCRIPTOR_HANDLE 
     }
 
     // Clear the resource.
-    this->cmd_list->ClearRenderTargetView(rtv, color, 0, nullptr);
+    this->cmd_list->ClearRenderTargetView(rtv, color, num_rects, rects);
 
     // Switch back to present.
     dst_barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
@@ -331,6 +331,14 @@ void CommandContext::clear_rtv(d3d12::TextureContext& tex, const float* color, D
     }
 
     this->clear_rtv(tex.texture.Get(), tex.get_rtv(), color, dst_state);
+}
+
+void CommandContext::clear_rtv(d3d12::TextureContext& tex, const float* color, const D3D12_RECT* rects, uint32_t num_rects, D3D12_RESOURCE_STATES dst_state) {
+    if (tex.texture == nullptr || tex.rtv_heap == nullptr) {
+        return;
+    }
+
+    this->clear_rtv(tex.texture.Get(), tex.get_rtv(), color, dst_state, rects, num_rects);
 }
 
 void CommandContext::execute() {

--- a/src/mods/vr/d3d12/CommandContext.hpp
+++ b/src/mods/vr/d3d12/CommandContext.hpp
@@ -30,9 +30,12 @@ struct CommandContext {
         UINT dstright_x, UINT dstright_y, UINT dstright_z,
         D3D12_RESOURCE_STATES src_state = D3D12_RESOURCE_STATE_PRESENT,
         D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-    void clear_rtv(ID3D12Resource* dst, D3D12_CPU_DESCRIPTOR_HANDLE rtv, const float* color, 
-        D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    void clear_rtv(ID3D12Resource* dst, D3D12_CPU_DESCRIPTOR_HANDLE rtv, const float* color,
+        D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
+        const D3D12_RECT* rects = nullptr, uint32_t num_rects = 0);
     void clear_rtv(TextureContext& tex, const float* color, D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    void clear_rtv(TextureContext& tex, const float* color, const D3D12_RECT* rects, uint32_t num_rects,
+        D3D12_RESOURCE_STATES dst_state = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
     void execute();
 
     bool ready() const {


### PR DESCRIPTION
## Chroma key passthrough for 2D Screen Mode

This adds the chroma keying support requested in #278. When enabled, the void around the 2D screen is cleared to a solid key color (magenta by default) instead of black, so Virtual Desktop's chroma key passthrough can replace it with your camera feed. You end up with the game floating in your real room.

### Usage

- Runtime page -> **Passthrough** -> enable **Chroma key void**, pick a color if magenta doesn't suit
- In Virtual Desktop: Streaming tab -> enable passthrough with chroma keying, set the key to the same color.

Here's my messy desk:

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/fe4f8c45-d959-4687-b74d-7237a1851358" />

The above image is with 2D mode in UEVR.

### Review notes

I had to rework a few parts of 2D Screen Mode for the passthrough to work, and those parts run even when it's disabled:

- The screen quads are opaque now instead of alpha blended. Robocop (my dx12 UE5 test game) output zero alpha, and with a magenta void behind them the whole game would tint magenta. Those same games currently render black in 2D mode for the same reason, so opaque seems like the right call either way.
- The projection layer behind the quad gets cleared instead of copying the blacked out backbuffer (that clear is where the key color goes), and depth isn't submitted anymore since it's just a flat color layer. With the feature off it clears to black, so it looks the same as before.
- D3D12 allocates the 2D screen textures unconditionally now, like D3D11 does. Before this, toggling 2D mode on mid-session on D3D12 hit null textures.


### Current Testing Scope

- Only Tested on Stray (DX11) and RoboCop: Rogue City (DX12).
- Currently only tested on Quest3 VD SteamVR + UEVR OpenXR. If we like this PR I can expand my testing and try to make sure it works across more modes.


