### PR TITLE
Detect double-precision view math in AVX-compiled UE5 binaries

### DIFF
--- a/src/mods/vr/FFakeStereoRenderingHook.cpp
+++ b/src/mods/vr/FFakeStereoRenderingHook.cpp
@@ -4,7 +4,9 @@
 #include <winternl.h>
 
 #include <asmjit/asmjit.h>
+#include <algorithm>
 #include <future>
+#include <string_view>
 
 #include <spdlog/spdlog.h>
 #include <utility/Memory.hpp>
@@ -65,6 +67,40 @@
 FFakeStereoRenderingHook* g_hook = nullptr;
 uint32_t g_frame_count{};
 
+namespace detail {
+// True for scalar (SD) and packed (PD) double-precision *arithmetic*, in both the legacy
+// SSE2 and the VEX/EVEX encodings. Games built with /arch:AVX or newer emit only the
+// V-prefixed forms, which carry entirely different bddisasm instruction IDs
+// (ND_INS_VADDSD is 734, ND_INS_ADDSD is 21), so matching on the enum alone misses them.
+//
+// Conversions are deliberately excluded: a float-precision binary can legitimately contain
+// a stray CVTSS2SD for an unrelated double literal, which proves nothing about the layout
+// of the struct this function operates on.
+bool is_double_precision_arithmetic(std::string_view mnemonic) {
+    if (mnemonic.size() > 1 && mnemonic.front() == 'V') {
+        mnemonic.remove_prefix(1); // VEX/EVEX encoding of the same operation
+    }
+
+    if (!mnemonic.ends_with("SD") && !mnemonic.ends_with("PD")) {
+        return false;
+    }
+
+    if (mnemonic.starts_with("CVT")) {
+        return false;
+    }
+
+    // FMA mnemonics carry an operand-order suffix (FMADD231SD), so match on the root.
+    static constexpr std::string_view roots[]{
+        "ADD", "SUB", "MUL", "DIV", "SQRT", "MAX", "MIN",
+        "FMADD", "FMSUB", "FNMADD", "FNMSUB", "HADD", "HSUB",
+    };
+
+    return std::any_of(std::begin(roots), std::end(roots), [mnemonic](std::string_view root) {
+        return mnemonic.starts_with(root);
+    });
+}
+}
+
 // Scan through function instructions to detect usage of double
 // floating point precision instructions.
 bool is_using_double_precision(uintptr_t addr) {
@@ -73,24 +109,34 @@ bool is_using_double_precision(uintptr_t addr) {
     bool result = false;
 
     utility::exhaustive_decode((uint8_t*)addr, 50, [&](INSTRUX& ix, uintptr_t ip) -> utility::ExhaustionResult {
-        if (std::string_view{ix.Mnemonic}.starts_with("CALL")) {
+        const std::string_view mnemonic{ix.Mnemonic};
+
+        if (mnemonic.starts_with("CALL")) {
             return utility::ExhaustionResult::STEP_OVER;
         }
 
-        if (ix.Instruction == ND_INS_MOVSD && ix.Operands[0].Type == ND_OP_MEM && ix.Operands[1].Type == ND_OP_REG) {
-            SPDLOG_INFO("[UE5 Detected] Detected Double precision MOVSD at {:x}", (uintptr_t)ip);
+        // A store of a scalar double to memory is the strongest possible signal: it means
+        // the struct field being written is 8 bytes wide.
+        if ((ix.Instruction == ND_INS_MOVSD || ix.Instruction == ND_INS_VMOVSD) &&
+            ix.Operands[0].Type == ND_OP_MEM && ix.Operands[1].Type == ND_OP_REG)
+        {
+            SPDLOG_INFO("[UE5 Detected] Detected Double precision store ({}) at {:x}", mnemonic, (uintptr_t)ip);
             result = true;
             return utility::ExhaustionResult::BREAK;
         }
 
-        if (ix.Instruction == ND_INS_ADDSD) {
-            SPDLOG_INFO("[UE5 Detected] Detected Double precision ADDSD at {:x}", (uintptr_t)ip);
+        if (detail::is_double_precision_arithmetic(mnemonic)) {
+            SPDLOG_INFO("[UE5 Detected] Detected Double precision arithmetic ({}) at {:x}", mnemonic, (uintptr_t)ip);
             result = true;
             return utility::ExhaustionResult::BREAK;
         }
 
         return utility::ExhaustionResult::CONTINUE;
     });
+
+    if (!result) {
+        SPDLOG_INFO("No double precision usage found at {:x}", addr);
+    }
 
     return result;
 }
@@ -1020,6 +1066,11 @@ bool FFakeStereoRenderingHook::standard_fake_stereo_hook(uintptr_t vtable) {
     SPDLOG_INFO("IsStereoEnabled: {:x}", (uintptr_t)*is_stereo_enabled_func_ptr);
 
     m_has_double_precision = is_using_double_precision(stereo_view_offset_func) || is_using_double_precision(calculate_stereo_projection_matrix_func);
+
+    // Getting this wrong silently corrupts every FVector/FRotator/FMatrix written back into
+    // the engine, so state the verdict outright rather than leaving it implicit in the
+    // absence of a detection message.
+    SPDLOG_INFO("Double precision (LWC) view math: {}", m_has_double_precision ? "YES" : "NO");
 
     {
         m_adjust_view_rect_hook = safetyhook::create_inline((void*)adjust_view_rect_func, adjust_view_rect);


### PR DESCRIPTION
### Problem

`is_using_double_precision` decides whether a UE5 title uses Large World Coordinates
(`FVector` = 3 doubles) by scanning `CalculateStereoViewOffset` and
`CalculateStereoProjectionMatrix` for double-precision instructions. It matches exactly two
bddisasm instruction IDs:

```cpp
if (ix.Instruction == ND_INS_MOVSD && ...)   // 394
if (ix.Instruction == ND_INS_ADDSD)          // 21
```

Those are the **legacy SSE2 encodings**. A game built with `/arch:AVX` or newer emits the VEX
forms instead, and bddisasm assigns those entirely different IDs — `ND_INS_VMOVSD` is 1108,
`ND_INS_VADDSD` is 734. The scan finds nothing and the title is treated as single precision.

Nothing in the log says so, because the function only logged on success. A misdetection left no
trace at all, which is why this is easy to miss.

### Evidence

Found on **Dune: Awakening** (UE 5.2.1, AVX-compiled). Static disassembly of the shipping binary:

```
CalculateStereoViewOffset          21 double-precision instructions
  vmovsd      qword ptr [rax], xmm0      <- 8-byte store of the view location
  vaddsd / vmulsd / vfmadd231sd          <- quaternion rotate on doubles

CalculateStereoProjectionMatrix    stores at 0x00, 0x28, 0x58, 0x70
                                   0x20 row stride -> FMatrix is 4x4 doubles, 128 bytes
```

Every one of them is VEX-encoded, so the current scan returns `false` for both functions.

### Impact when the verdict is wrong

The damage is silent and total, because UEVR then reads and writes the engine's structures with
the wrong layout:

| Path | Consequence |
|---|---|
| `*view_location -= eye_separation` | writes 3 floats at offsets 0/4/8 into an `FVector3d`; the float `y` lands on **bytes 4-7 — the sign and exponent of double X**, so the view position is destroyed rather than offset |
| `view_rotation->yaw/pitch/roll` | read as floats at 0/4/8 while the real `FRotator` doubles sit at 0/8/16 |
| `*out = get_projection_matrix()` | writes a 64-byte float matrix into a 128-byte `FMatrix` |
| `old_znear = (*out)[3][2]` | reads a float at offset 56; the real near-Z is a double at offset 112 |
| `is_full_pass` | becomes true for `view_index == 0`, so the left-eye pass is treated as monoscopic |
| `GetViewPassForIndex` | never hooked at all — its install is gated on the same flag |

Net effect: Native Stereo renders black.

### Fix

Accept `VMOVSD` memory-to-register stores alongside `MOVSD`, and accept scalar (`SD`) and packed
(`PD`) double arithmetic by mnemonic after stripping the `V` prefix. `CVT*` is deliberately
excluded — a stray float-to-double conversion says nothing about the layout of the struct being
written, so including it would risk false positives on genuinely single-precision UE4 titles.

The store check keeps its original `MEM <- REG` operand constraint, so it still only fires on an
actual 8-byte store.

Also logs the verdict unconditionally. One line, and it turns a silent misdetection into
something visible in the log.

### Result

With this change, on the same build, the engine's stereo view loop runs normally:
`GetViewPassForIndex` receives index 0 and index 1 once each per frame, and
`CalculateStereoViewOffset` counts come out 1:1 between the eyes. Native Stereo renders a correct
per-eye image.

### Testing notes, and one caveat I want to be upfront about

The change is built and running against joeyhodge's `DuneFixes` tree, where the identical edit
produced the result above. I could **not** compile this branch against `praydog/UEVR@master`
directly, because the `dependencies/submodules/UESDK` submodule is private and I have no access —
so this exact tree is unbuilt by me. The edit is confined to one self-contained function plus one
log line, but please treat it accordingly.

I have no way to test the change against a single-precision UE4 title. The `CVT*` exclusion is
there specifically to keep that case safe, but a second opinion on the mnemonic set would be
welcome.

Related: joeyhodge's fork carries a workaround that forces double precision for UE 5.0-5.3 by
engine version. That masks the symptom for those versions but leaves an AVX-compiled UE 5.4+
title misdetected, which is what this aims to fix at the root.
