### PR TITLE
Fix the gamma hook landing on a garbage vtable slot

### DIFF
--- a/src/mods/vr/FFakeStereoRenderingHook.cpp
+++ b/src/mods/vr/FFakeStereoRenderingHook.cpp
@@ -7278,8 +7278,17 @@ bool VRRenderTargetManager_Base::create_scene_capture() try {
         auto viewport = rtm != nullptr ? rtm->get_viewport() : nullptr;
 
         if (viewport != nullptr) {
-            return viewport->get_display_gamma();
+            const auto gamma = viewport->get_display_gamma();
+
+            // Logged because the two branches look the same on screen. A viewport reporting 2.2 and a
+            // missing viewport falling back to 2.2 give the same picture, but only this one follows the
+            // game's own gamma setting.
+            SPDLOG_INFO_ONCE("[FRenderTarget] Matching the scene capture's display gamma to the viewport's, currently {}", gamma);
+
+            return gamma;
         }
+
+        SPDLOG_WARN_ONCE("[FRenderTarget] No viewport to read the display gamma from, assuming 2.2");
 
         return 2.2f;
     };
@@ -7295,7 +7304,18 @@ bool VRRenderTargetManager_Base::create_scene_capture() try {
         auto& vtable = *(void**)frt;
         memcpy(original_frender_target_vtable.data(), vtable, original_frender_target_vtable.size() * sizeof(uintptr_t));
 
-        if (auto display_gamma_index = sdk::FRenderTarget::get_display_gamma_index(); display_gamma_index != 0) {
+        // has_value(), not != 0.
+        //
+        // An empty std::optional compares as less than any number, so "index != 0" was true exactly when
+        // the index had not been found. Dereferencing it wrote gamma_increase_fn at whatever slot that
+        // produced, and the vtable was swapped to that copy. In the log it shows up as a failed search
+        // with "Hooked FRenderTarget!" on the next line.
+        if (const auto display_gamma_index = sdk::FRenderTarget::get_display_gamma_index(); display_gamma_index.has_value()) {
+            if (*display_gamma_index >= original_frender_target_vtable.size()) {
+                SPDLOG_WARN("[FRenderTarget] Gamma index {} is out of range, can't hook!", *display_gamma_index);
+                return;
+            }
+
             original_frender_target_vtable[*display_gamma_index] = (uintptr_t)gamma_increase_fn;
             vtable = original_frender_target_vtable.data();
             SPDLOG_INFO("[FRenderTarget] Hooked FRenderTarget!");


### PR DESCRIPTION
The check on the gamma index compares a `std::optional` with 0:

```cpp
if (auto display_gamma_index = sdk::FRenderTarget::get_display_gamma_index(); display_gamma_index != 0) {
```

An empty optional compares as less than any number, so this is true exactly when the
index was **not** found. `gamma_increase_fn` then gets written at whatever slot the
empty optional produces, and the render target's vtable pointer is swapped to that
copy. In the log it looks like this:

```
Failed to find FRenderTarget::GetDisplayGamma vtable index
[FRenderTarget] Hooked FRenderTarget!
```

Uses `has_value()` now, and gives up if the index is past the end of the copied vtable
instead of writing outside it.

Also logs which of the two sources the gamma came from, once. A viewport reporting 2.2
and a missing viewport falling back to the constant 2.2 give the same picture, so there
was no way to tell a working hook from one that happens to look right.

On its own this turns a silent vtable corruption into a warning. For the index to be
found at all, the searches in UESDK need fixing too, which is a separate PR over there:
https://github.com/praydog/UESDK/pull/2. The two don't depend on each other to build or
merge, they just need each other to fix the dark eye.

### Tested

Release build, three games with the native stereo fix on. With both changes the hook
installs and the second eye matches the first. Gamma values are from the new log line:

| game | UE | GetDisplayGamma index | gamma taken from the viewport |
|---|---|---|---|
| The Outer Worlds 2 | 5 | 7 | 1.9999999 |
| Silent Hill 2 | 5 | 5 | 2.2 |
| Gylt | 4 | 4 | 2.4999998 |

Each value matches that game's own gamma setting. I changed The Outer Worlds 2 from 2.2
to 2.0 and the logged value followed, so it is reading the viewport and not the 2.2
fallback.