### PR TITLE
Bind print, and stop the log_* wrappers from crashing when called with a colon

### DIFF
--- a/lua-api/lib/src/ScriptContext.cpp
+++ b/lua-api/lib/src/ScriptContext.cpp
@@ -1147,6 +1147,57 @@ int ScriptContext::setup_bindings() {
         }
     );
 
+    // Lua's stock print writes to stdout, which the game process does not have, so it needs
+    // a binding to reach the log at all. print and log.info go through ScriptContext::log,
+    // log.warn and log.error take the matching API levels. Arguments run through Lua's own
+    // tostring, so any type works and they are tab separated, same as stock print.
+    {
+        auto stringify = [](sol::this_state s, sol::variadic_args args) -> std::string {
+            sol::state_view lua{s};
+            sol::function tostring = lua["tostring"];
+
+            std::string out{};
+
+            for (auto arg : args) {
+                if (!out.empty()) {
+                    out += "\t";
+                }
+
+                auto piece = tostring(arg);
+
+                if (piece.valid() && piece.get_type() == sol::type::string) {
+                    out += piece.get<std::string>();
+                } else {
+                    out += "<?>";
+                }
+            }
+
+            return out;
+        };
+
+        m_lua["print"] = [stringify](sol::this_state s, sol::variadic_args args) {
+            ScriptContext::log(stringify(s, args));
+        };
+
+        auto log_table = m_lua.create_table();
+
+        log_table["info"] = [stringify](sol::this_state s, sol::variadic_args args) {
+            ScriptContext::log(stringify(s, args));
+        };
+
+        log_table["warn"] = [stringify](sol::this_state s, sol::variadic_args args) {
+            const auto msg = stringify(s, args);
+            uevr::API::get()->log_warn("[LuaVR] %s", msg.c_str());
+        };
+
+        log_table["error"] = [stringify](sol::this_state s, sol::variadic_args args) {
+            const auto msg = stringify(s, args);
+            uevr::API::get()->log_error("[LuaVR] %s", msg.c_str());
+        };
+
+        m_lua["log"] = log_table;
+    }
+
     setup_callback_bindings();
 
     auto out = m_lua.create_table();

--- a/lua-api/lib/src/ScriptContext.cpp
+++ b/lua-api/lib/src/ScriptContext.cpp
@@ -380,9 +380,25 @@ int ScriptContext::setup_bindings() {
     );
 
     m_lua.new_usertype<UEVR_PluginFunctions>("UEVR_PluginFunctions",
-        "log_error", &UEVR_PluginFunctions::log_error,
-        "log_warn", &UEVR_PluginFunctions::log_warn,
-        "log_info", &UEVR_PluginFunctions::log_info,
+        // Wrapped rather than bound directly, because these are C variadics in API.h: a ':'
+        // call would leave self in the format parameter and printf would read the struct
+        // pointer as a format string. Passing a ready string as an argument to "%s" also
+        // keeps percent signs in the message harmless.
+        "log_error", [](UEVR_PluginFunctions* self, const char* message) {
+            if (self != nullptr && message != nullptr) {
+                self->log_error("%s", message);
+            }
+        },
+        "log_warn", [](UEVR_PluginFunctions* self, const char* message) {
+            if (self != nullptr && message != nullptr) {
+                self->log_warn("%s", message);
+            }
+        },
+        "log_info", [](UEVR_PluginFunctions* self, const char* message) {
+            if (self != nullptr && message != nullptr) {
+                self->log_info("%s", message);
+            }
+        },
         "is_drawing_ui", &UEVR_PluginFunctions::is_drawing_ui,
 
         "get_commit_hash", &UEVR_PluginFunctions::get_commit_hash,


### PR DESCRIPTION
Two things that bite anyone writing Lua for UEVR. One file, one commit each, and they are
independent if you only want one of them.

### `print` did nothing

There is no binding for it, so the stock implementation runs and writes to a stdout the game
does not have. Nothing reaches log.txt and there is no error either. It just looks like the
script never ran, which is an easy hour to lose.

`lua-api/examples/hello_world.lua` is built almost entirely on `print`, so the example that
ships with the repo currently produces no output at all.

`ScriptContext::log` already does the right thing (OutputDebugStringA, stderr, and
`API::log_info` with a `%s` format), it was only used internally. `print` now goes through
it. Arguments are stringified by Lua's own `tostring`, so any type works and arguments are
tab separated, same as stock print.

### `log_info` crashes if you call it the usual way

The three fields are declared in API.h as C variadics:

```c
void (*log_info)(const char* format, ...);
```

They were bound straight through, so this kills the process:

```lua
uevr.params.functions:log_info("hello")
```

These are struct fields, not methods, so sol uses the object only to fetch the pointer and
then forwards whatever Lua passed. The colon adds the object as an extra first argument, so
the format parameter gets something that is not a format string and printf reads it as one.
It is an access violation rather than a Lua error, so `pcall` does not help and the log ends
mid-line. With a dot it works, but the message itself is the format string, so any `%` in it
is a landmine.

The wrappers now take a ready string and pass it as an argument to `"%s"`. Percent signs in
the text are harmless and the colon syntax keeps working.

Also adds a global `log` table with `info`, `warn` and `error`, since the warn and error
levels had no safe route at all. If a global is too much, say so and I will move it under
`uevr`.

### Tested

Release build, The Outer Worlds 2 (UE5). Before: `functions:log_info("...")` took the game
down while the script was still loading, and no `print` output ever appeared in log.txt.
After: both write to log.txt, and a `%` in the message no longer matters. Been running on
it daily for a couple of weeks.